### PR TITLE
Ability to specify Scala installation directory

### DIFF
--- a/src/main/java/org_scala_tools_maven/ScalaConsoleMojo.java
+++ b/src/main/java/org_scala_tools_maven/ScalaConsoleMojo.java
@@ -18,6 +18,7 @@ package org_scala_tools_maven;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -73,9 +74,9 @@ public class ScalaConsoleMojo extends ScalaMojoSupport {
     protected void doExecute() throws Exception {
         //TODO - Many other paths uses the getScalaCommand()!!! We should try to use that as much as possibel to help maintainability.
         String sv = findScalaVersion().toString();
-        Set<String> classpath = new HashSet<String>();
+        Set<String> classpath = new LinkedHashSet<String>();
         addCompilerToClasspath(sv, classpath);
-        addToClasspath("org.scala-lang", "scala-library", sv, classpath);
+        addLibraryToClasspath(sv, classpath);
         addToClasspath("jline", "jline", "0.9.94", classpath);
         classpath.addAll(project.getCompileClasspathElements());
         if (useTestClasspath) {

--- a/src/main/java/org_scala_tools_maven/ScalaMojoSupport.java
+++ b/src/main/java/org_scala_tools_maven/ScalaMojoSupport.java
@@ -333,6 +333,17 @@ public abstract class ScalaMojoSupport extends AbstractMojo {
         }
     }
 
+    protected void addLibraryToClasspath(String version, Set<String> classpath) throws Exception {
+        if(StringUtils.isEmpty(scalaHome)) {
+            addToClasspath(SCALA_GROUPID, SCALA_LIBRARY_ARTIFACTID, version, classpath);
+        } else {
+            // Note that in this case we have to ignore dependencies.
+            File lib = new File(scalaHome, "lib");
+            File libraryJar = new File(lib, "scala-library.jar");
+            classpath.add(libraryJar.toString());
+        }
+    }
+
     protected void addToClasspath(Artifact artifact, Set<String> classpath, boolean addDependencies) throws Exception {
         resolver.resolve(artifact, remoteRepos, localRepo);
         classpath.add(artifact.getFile().getCanonicalPath());
@@ -385,7 +396,7 @@ public abstract class ScalaMojoSupport extends AbstractMojo {
             }
             if (StringUtils.isEmpty(detectedScalaVersion)) {
                 if (!"pom".equals( project.getPackaging().toLowerCase() )) {
-                    getLog().warn("you don't define "+SCALA_GROUPID + ":" + SCALA_LIBRARY_ARTIFACTID + " as a dependency of the project");
+                    getLog().warn("you don't define " + SCALA_GROUPID + ":" + SCALA_LIBRARY_ARTIFACTID + " as a dependency of the project");
                 }
                 detectedScalaVersion = "0.0.0";
             } else {
@@ -528,8 +539,8 @@ public abstract class ScalaMojoSupport extends AbstractMojo {
     }
 
     private String getBootClasspath() throws Exception {
-        Set<String> classpath = new HashSet<String>();
-        addToClasspath(SCALA_GROUPID, SCALA_LIBRARY_ARTIFACTID, findScalaVersion().toString(), classpath);
+        Set<String> classpath = new LinkedHashSet<String>();
+        addLibraryToClasspath(findScalaVersion().toString(), classpath);
         return MainHelper.toMultiPath(classpath.toArray(new String[classpath.size()]));
     }
 
@@ -561,10 +572,10 @@ public abstract class ScalaMojoSupport extends AbstractMojo {
     private Set<String> getCompilerPlugins() throws Exception {
         Set<String> plugins = new HashSet<String>();
         if (compilerPlugins != null) {
-            Set<String> ignoreClasspath = new HashSet<String>();
+            Set<String> ignoreClasspath = new LinkedHashSet<String>();
             String sv = findScalaVersion().toString();
             addCompilerToClasspath(sv, ignoreClasspath);
-            addToClasspath(SCALA_GROUPID, SCALA_LIBRARY_ARTIFACTID, sv, ignoreClasspath);
+            addLibraryToClasspath(sv, ignoreClasspath);
             for (BasicArtifact artifact : compilerPlugins) {
                 getLog().info("compiler plugin: " + artifact.toString());
                 // TODO - Ensure proper scala version for plugins

--- a/src/main/java/org_scala_tools_maven/ScalaScriptMojo.java
+++ b/src/main/java/org_scala_tools_maven/ScalaScriptMojo.java
@@ -334,7 +334,7 @@ public class ScalaScriptMojo extends ScalaMojoSupport {
 //        classpath.add( outputDirectory);
         String sv = findScalaVersion().toString();
         addCompilerToClasspath(sv, classpath);
-        addToClasspath("org.scala-lang", "scala-library", sv, classpath);
+        addLibraryToClasspath(sv, classpath);
         //TODO check that every entry from the classpath exists !
         boolean ok = true;
         for (String s : classpath) {


### PR DESCRIPTION
These patches introduce scalaHome configuration parameter and scala.home property that allow specifying Scala installation directory. If either of them is used, then maven-scala-plugin will use Scala JARs from the specified directory rather than from Maven artifacts.

With these patches, the following pom can be used to quickly switch between different Scala installations:

```
<project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
  <modelVersion>4.0.0</modelVersion>
  <groupId>org</groupId>
  <artifactId>example</artifactId>
  <packaging>jar</packaging>
  <version>1.0-SNAPSHOT</version>
  <name>example</name>
  <profiles>
    <profile>
      <id>scala-home</id>
      <activation>
        <property>
          <name>scala.home</name>
        </property>
      </activation>
      <dependencies>
        <dependency>
          <groupId>org.scala-lang</groupId>
          <artifactId>scala-library</artifactId>
          <version>2.9.0-SNAPSHOT</version>
          <scope>system</scope>
          <systemPath>${scala.home}/lib/scala-library.jar</systemPath>
        </dependency>
      </dependencies>
    </profile>
    <profile>
      <id>scala-artifact</id>
      <activation>
        <property>
          <name>!scala.home</name>
        </property>
      </activation>
      <dependencies>
        <dependency>
          <groupId>org.scala-lang</groupId>
          <artifactId>scala-library</artifactId>
          <version>2.9.0-SNAPSHOT</version>
        </dependency>
      </dependencies>
    </profile>
  </profiles>
  <build>
    <plugins>
      <plugin>
        <groupId>org.scala-tools</groupId>
        <artifactId>maven-scala-plugin</artifactId>
        <version>2.15.3-SNAPSHOT</version>
        <configuration>
          <scalaVersion>2.9.0-SNAPSHOT</scalaVersion>
        </configuration>
      </plugin>
    </plugins>
  </build>
</project>
```
