### PR TITLE
fixes https://github.com/davidB/maven-scala-plugin/issues/50

### DIFF
--- a/src/main/java/org_scala_tools_maven/AddSourceMojo.java
+++ b/src/main/java/org_scala_tools_maven/AddSourceMojo.java
@@ -40,14 +40,14 @@ public class AddSourceMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException {
         try {
             if (sourceDir != null) {
-                String path = sourceDir.getCanonicalPath();
+                String path = sourceDir.getAbsolutePath();
                 if (!project.getCompileSourceRoots().contains(path)) {
                     getLog().info("Add Source directory: " + path);
                     project.addCompileSourceRoot(path);
                 }
             }
             if (testSourceDir != null) {
-                String path = testSourceDir.getCanonicalPath();
+                String path = testSourceDir.getAbsolutePath();
                 if (!project.getTestCompileSourceRoots().contains(path)) {
                     getLog().info("Add Test Source directory: " + path);
                     project.addTestCompileSourceRoot(path);

--- a/src/main/java/org_scala_tools_maven/ScalaCompileMojo.java
+++ b/src/main/java/org_scala_tools_maven/ScalaCompileMojo.java
@@ -49,7 +49,7 @@ public class ScalaCompileMojo extends ScalaCompilerSupport {
     protected List<File> getSourceDirectories() throws Exception {
         List<String> sources = project.getCompileSourceRoots();
         //Quick fix in case the user has not added the "add-source" goal.
-        String scalaSourceDir = sourceDir.getCanonicalPath();
+        String scalaSourceDir = sourceDir.getAbsolutePath();
         if(!sources.contains(scalaSourceDir)) {
             sources.add(scalaSourceDir);
         }

--- a/src/main/java/org_scala_tools_maven/ScalaCompilerSupport.java
+++ b/src/main/java/org_scala_tools_maven/ScalaCompilerSupport.java
@@ -74,7 +74,7 @@ public abstract class ScalaCompilerSupport extends ScalaSourceMojoSupport {
         }
         if (getLog().isDebugEnabled()) {
             for(File directory : getSourceDirectories()) {
-                getLog().debug(directory.getCanonicalPath());
+                getLog().debug(directory.getAbsolutePath());
             }
         }
         int nbFiles = compile(getSourceDirectories(), outputDir, getClasspathElements(), false);
@@ -193,7 +193,7 @@ public abstract class ScalaCompilerSupport extends ScalaSourceMojoSupport {
     private void notifyCompilation(List<File> files) throws Exception {
         if (notifyCompilation) {
             for (File f : files) {
-                getLog().info(String.format("%s:-1: info: compiling", f.getCanonicalPath()));
+                getLog().info(String.format("%s:-1: info: compiling", f.getAbsolutePath()));
             }
         }
     }

--- a/src/main/java/org_scala_tools_maven/ScalaConsoleMojo.java
+++ b/src/main/java/org_scala_tools_maven/ScalaConsoleMojo.java
@@ -104,9 +104,9 @@ public class ScalaConsoleMojo extends ScalaMojoSupport {
         addCompilerPluginOptions(jcmd);
         if (javaRebelPath != null) {
             if (!javaRebelPath.exists()) {
-                getLog().warn("javaRevelPath '"+javaRebelPath.getCanonicalPath()+"' not found");
+                getLog().warn("javaRevelPath '"+javaRebelPath.getAbsolutePath()+"' not found");
             } else {
-                jcmd.addJvmArgs("-noverify", "-javaagent:" + javaRebelPath.getCanonicalPath());
+                jcmd.addJvmArgs("-noverify", "-javaagent:" + javaRebelPath.getAbsolutePath());
             }
         }
         jcmd.run(displayCmd);

--- a/src/main/java/org_scala_tools_maven/ScalaDocMojo.java
+++ b/src/main/java/org_scala_tools_maven/ScalaDocMojo.java
@@ -200,7 +200,7 @@ public class ScalaDocMojo extends ScalaSourceMojoSupport implements MavenReport 
     protected List<File> getSourceDirectories() throws Exception {
         List<String> sources = project.getCompileSourceRoots();
         //Quick fix in case the user has not added the "add-source" goal.
-        String scalaSourceDir = sourceDir.getCanonicalPath();
+        String scalaSourceDir = sourceDir.getAbsolutePath();
         if(!sources.contains(scalaSourceDir)) {
             sources.add(scalaSourceDir);
         }
@@ -353,7 +353,7 @@ public class ScalaDocMojo extends ScalaSourceMojoSupport implements MavenReport 
                 JavaMainCaller jcmd = getScalaCommand();
                 jcmd.addOption("-d", reportOutputDir.getAbsolutePath());
                 for (File x : sources) {
-                    jcmd.addArgs(x.getCanonicalPath());
+                    jcmd.addArgs(x.getAbsolutePath());
                 }
                 jcmd.run(displayCmd);
             }

--- a/src/main/java/org_scala_tools_maven/ScalaGenJsonMojo.java
+++ b/src/main/java/org_scala_tools_maven/ScalaGenJsonMojo.java
@@ -142,7 +142,7 @@ public class ScalaGenJsonMojo extends ScalaSourceMojoSupport {
   protected List<File> getSourceDirectories() throws Exception {
     List<String> sources = project.getCompileSourceRoots();
     // Quick fix in case the user has not added the "add-source" goal.
-    String scalaSourceDir = sourceDir.getCanonicalPath();
+    String scalaSourceDir = sourceDir.getAbsolutePath();
     if (!sources.contains(scalaSourceDir)) {
       sources.add(scalaSourceDir);
     }
@@ -157,7 +157,7 @@ public class ScalaGenJsonMojo extends ScalaSourceMojoSupport {
       setDependenciesForJcmd();
       JavaMainCaller jcmd = getEmptyScalaCommand(_mainClass);
       jcmd.addJvmArgs(jvmArgs);
-      jcmd.addArgs(cfgFile.getCanonicalPath());
+      jcmd.addArgs(cfgFile.getAbsolutePath());
       jcmd.run(displayCmd);
       registerApidocArchiveForInstall(cfg);
     } else {
@@ -268,7 +268,7 @@ public class ScalaGenJsonMojo extends ScalaSourceMojoSupport {
       List<Artifact> deps = data.project.getCompileArtifacts();
       for (Artifact dep : deps) {
         List<String> e = new ArrayList<String>(3);
-        e.add(dep.getFile().getCanonicalPath());
+        e.add(dep.getFile().getAbsolutePath());
         e.add(dep.getArtifactId() + "/" + dep.getVersion());
         back.add(e);
       }
@@ -282,7 +282,7 @@ public class ScalaGenJsonMojo extends ScalaSourceMojoSupport {
       List<String> excludes = new ArrayList<String>(data.excludes);
       for (File dir : dirs) {
         List<Object> e = new ArrayList<Object>(3);
-        e.add(dir.getCanonicalPath());
+        e.add(dir.getAbsolutePath());
         e.add(excludes);
         e.add(includes);
         back.add(e);

--- a/src/main/java/org_scala_tools_maven/ScalaMojoSupport.java
+++ b/src/main/java/org_scala_tools_maven/ScalaMojoSupport.java
@@ -314,10 +314,10 @@ public abstract class ScalaMojoSupport extends AbstractMojo {
 
     protected void addToClasspath(Artifact artifact, Set<String> classpath, boolean addDependencies) throws Exception {
         resolver.resolve(artifact, remoteRepos, localRepo);
-        classpath.add(artifact.getFile().getCanonicalPath());
+        classpath.add(artifact.getFile().getAbsolutePath());
         if (addDependencies) {
             for (Artifact dep : resolveArtifactDependencies(artifact)) {
-                //classpath.add(dep.getFile().getCanonicalPath());
+                //classpath.add(dep.getFile().getAbsolutePath());
                 addToClasspath(dep, classpath, addDependencies);
             }
         }

--- a/src/main/java/org_scala_tools_maven_cs/ScalaCSInitMojo.java
+++ b/src/main/java/org_scala_tools_maven_cs/ScalaCSInitMojo.java
@@ -129,12 +129,12 @@ public class ScalaCSInitMojo extends ScalaCSMojoSupport {
         if (excludes != null) {
             dataCompile.put("excludes", new ArrayList<String>(excludes));
         }
-        dataCompile.put("targetDir", outputDir.getCanonicalPath());
+        dataCompile.put("targetDir", outputDir.getAbsolutePath());
         dataCompile.put("classpath", project.getCompileClasspathElements());
         if (args != null) {
             dataCompile.put("args", args);
         }
-        dataCompile.put("exported", new File(localRepo.getBasedir() , localRepo.pathOf(project.getArtifact())).getCanonicalPath());
+        dataCompile.put("exported", new File(localRepo.getBasedir() , localRepo.pathOf(project.getArtifact())).getAbsolutePath());
 
         HashMap<String, Object> dataTest = new HashMap<String, Object>();
         dataTest.put("name", project.getArtifactId()+"-"+project.getVersion() +"/test");
@@ -145,7 +145,7 @@ public class ScalaCSInitMojo extends ScalaCSMojoSupport {
         if (excludes != null) {
             dataTest.put("excludes", new ArrayList<String>(excludes));
         }
-        dataTest.put("targetDir", testOutputDir.getCanonicalPath());
+        dataTest.put("targetDir", testOutputDir.getAbsolutePath());
         dataTest.put("classpath", project.getTestClasspathElements());
         if (args != null) {
             dataTest.put("args", args);
@@ -162,7 +162,7 @@ public class ScalaCSInitMojo extends ScalaCSMojoSupport {
     protected List<String> getSourceDirectories() throws Exception {
         List<String> sources = project.getCompileSourceRoots();
         //Quick fix in case the user has not added the "add-source" goal.
-        String scalaSourceDir = sourceDir.getCanonicalPath();
+        String scalaSourceDir = sourceDir.getAbsolutePath();
         if(!sources.contains(scalaSourceDir)) {
             sources.add(scalaSourceDir);
         }

--- a/src/main/java/org_scala_tools_maven_cs/ScalacsClient.java
+++ b/src/main/java/org_scala_tools_maven_cs/ScalacsClient.java
@@ -214,7 +214,7 @@ public class ScalacsClient {
         _mojo.addToClasspath("org.scala-tools.sbt", "sbt-launch", "0.7.2", classpath, true);
         String[] jvmArgs = new String[(_jvmArgs == null)?1:_jvmArgs.length + 1];
         File installDir = new File(System.getProperty("user.home"), ".sbt-launch");
-        jvmArgs[0] = "-Dsbt.boot.properties="+ installConf(new File(installDir, _csArtifactId + "-"+ _csVersion +".boot.properties")).getCanonicalPath();
+        jvmArgs[0] = "-Dsbt.boot.properties="+ installConf(new File(installDir, _csArtifactId + "-"+ _csVersion +".boot.properties")).getAbsolutePath();
         if (_jvmArgs != null) {
             System.arraycopy(_jvmArgs, 0, jvmArgs, 1, _jvmArgs.length);
         }
@@ -276,9 +276,9 @@ public class ScalacsClient {
             p.setProperty("scalacs.groupId", _csGroupId);
             p.setProperty("scalacs.artifactId", _csArtifactId);
             p.setProperty("scalacs.version", _csVersion);
-            p.setProperty("scalacs.directory", scalaCsBootConf.getParentFile().getCanonicalPath());
+            p.setProperty("scalacs.directory", scalaCsBootConf.getParentFile().getAbsolutePath());
             String cfg = StringUtils.interpolate(sw.toString(), p);
-            FileUtils.fileWrite(scalaCsBootConf.getCanonicalPath(), "UTF-8", cfg);
+            FileUtils.fileWrite(scalaCsBootConf.getAbsolutePath(), "UTF-8", cfg);
         }
         return scalaCsBootConf;
     }

--- a/src/main/java/org_scala_tools_maven_executions/JavaMainCallerByFork.java
+++ b/src/main/java/org_scala_tools_maven_executions/JavaMainCallerByFork.java
@@ -97,10 +97,10 @@ public class JavaMainCallerByFork extends JavaMainCallerSupport {
         List<String> cmd = buildCommand();
         File out = new File(System.getProperty("java.io.tmpdir"), mainClassName +".out");
         out.delete();
-        cmd.add(">"+ out.getCanonicalPath());
+        cmd.add(">"+ out.getAbsolutePath());
         File err = new File(System.getProperty("java.io.tmpdir"), mainClassName +".err");
         err.delete();
-        cmd.add("2>"+ err.getCanonicalPath());
+        cmd.add("2>"+ err.getAbsolutePath());
         List<String> cmd2 = new ArrayList<String>();
         String cmdStr = StringUtils.join(cmd.iterator(), " ");
         if (OS.isFamilyDOS()) {
@@ -150,7 +150,7 @@ public class JavaMainCallerByFork extends JavaMainCallerSupport {
             back.addAll(jvmArgs);
             back.add(MainWithArgsInFile.class.getName());
             back.add(mainClassName);
-            back.add(MainHelper.createArgFile(args).getCanonicalPath());
+            back.add(MainHelper.createArgFile(args).getAbsolutePath());
         }
         return back;
     }

--- a/src/main/java/org_scala_tools_maven_executions/JavaMainCallerSupport.java
+++ b/src/main/java/org_scala_tools_maven_executions/JavaMainCallerSupport.java
@@ -49,7 +49,7 @@ public abstract class JavaMainCallerSupport implements JavaMainCaller {
         for (int i = 0; i < jvmArgs.size(); i++) {
             String item = jvmArgs.get(i);
             if (isClasspath) {
-                item = item + File.pathSeparator + entry.getCanonicalPath();
+                item = item + File.pathSeparator + entry.getAbsolutePath();
                 jvmArgs.set(i, item);
                 isClasspath = false;
                 break;


### PR DESCRIPTION
This patch fixes issue #50 (https://github.com/davidB/maven-scala-plugin/issues/50).
It just replaces all occurrences of getCanonicalPath by getAbsolutePath, since the use of canonical paths seems to be incompatible with the Java compiler plugin.
