### PR TITLE
Pull in stdin and stderr

### DIFF
--- a/src/main/java/org_scala_tools_maven_executions/JavaMainCallerByFork.java
+++ b/src/main/java/org_scala_tools_maven_executions/JavaMainCallerByFork.java
@@ -57,7 +57,7 @@ public class JavaMainCallerByFork extends JavaMainCallerSupport {
 
         //err and out are redirected to out
         if (!_redirectToLog) {
-            exec.setStreamHandler(new PumpStreamHandler(System.out));
+            exec.setStreamHandler(new PumpStreamHandler(System.out, System.err, System.in));
         } else {
             exec.setStreamHandler(new PumpStreamHandler(new LogOutputStream() {
                 private LevelState _previous = new LevelState();


### PR DESCRIPTION
System.in is necessary, if the scala class run is interactive. Is this
is a bad idea for general usage, a flag should be introduced.

Signed-off-by: Christoph Höger christoph.hoeger@tu-berlin.de
