### PR TITLE
Use Maven 3.0 toolchain API to configure a specific JDK to build with

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
   </contributors>
 
   <properties>
-    <maven.version>2.2.1</maven.version>
+    <maven.version>3.0</maven.version>
     <maven.compiler.source>1.5</maven.compiler.source>
     <maven.compiler.target>1.5</maven.compiler.target>
     <encoding>UTF-8</encoding>
@@ -92,11 +92,6 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>${maven.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-project</artifactId>
       <version>${maven.version}</version>
     </dependency>
     <dependency>
@@ -122,7 +117,8 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
-      <version>${maven.version}</version>
+      <!-- Need this because some needed classes were removed from maven-artifact 3.0 -->
+      <version>2.2.1</version>
     </dependency>
      <dependency>
        <groupId>org.codehaus.plexus</groupId>

--- a/src/main/java/scala_maven/ScalaGenJsonMojo.java
+++ b/src/main/java/scala_maven/ScalaGenJsonMojo.java
@@ -2,6 +2,7 @@ package scala_maven;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -19,8 +20,6 @@ import org.codehaus.jackson.node.ObjectNode;
 import org.codehaus.plexus.util.StringUtils;
 
 import scala_maven_executions.JavaMainCaller;
-
-import edu.emory.mathcs.backport.java.util.Arrays;
 
 /**
  * Produces Scala API documentation in Json (use vscaladoc2_genjson).

--- a/src/main/java/scala_maven/ScalaMojoSupport.java
+++ b/src/main/java/scala_maven/ScalaMojoSupport.java
@@ -17,6 +17,7 @@ import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.artifact.resolver.filter.AndArtifactFilter;
 import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
 import org.apache.maven.artifact.resolver.filter.ScopeArtifactFilter;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -33,6 +34,7 @@ import org.apache.maven.shared.dependency.tree.filter.DependencyNodeFilter;
 import org.apache.maven.shared.dependency.tree.traversal.CollectingDependencyNodeVisitor;
 import org.apache.maven.shared.dependency.tree.traversal.DependencyNodeVisitor;
 import org.apache.maven.shared.dependency.tree.traversal.FilteringDependencyNodeVisitor;
+import org.apache.maven.toolchain.ToolchainManager;
 import org.codehaus.plexus.util.StringUtils;
 import scala_maven_dependency.CheckScalaVersionVisitor;
 import scala_maven_dependency.ScalaDistroArtifactFilter;
@@ -52,6 +54,13 @@ public abstract class ScalaMojoSupport extends AbstractMojo {
      * @readonly
      */
     protected MavenProject project;
+
+    /**
+     * @parameter expression="${session}"
+     * @required
+     * @readonly
+     */
+    protected MavenSession session;
 
     /**
      * Used to look up Artifacts in the remote repository.
@@ -256,6 +265,15 @@ public abstract class ScalaMojoSupport extends AbstractMojo {
      * @readonly
      */
     private DependencyTreeBuilder dependencyTreeBuilder;
+
+    /**
+     * The toolchain manager to use.
+     *
+     * @component
+     * @required
+     * @readonly
+     */
+    protected ToolchainManager toolchainManager;
 
     private VersionNumber _scalaVersionN;
 
@@ -488,7 +506,8 @@ public abstract class ScalaMojoSupport extends AbstractMojo {
            // * works only since 2.8.0
            // * is buggy (don't manage space in path on windows)
             getLog().debug("use java command with args in file forced : " + forceUseArgFile);
-            cmd = new JavaMainCallerByFork(this, mainClass, getToolClasspath(), null, null, forceUseArgFile);
+
+            cmd = new JavaMainCallerByFork(this, mainClass, getToolClasspath(), null, null, forceUseArgFile, toolchainManager.getToolchainFromBuildContext("jdk", session));
         } else  {
             cmd = new JavaMainCallerInProcess(this, mainClass, getToolClasspath(), null, null);
         }

--- a/src/main/java/scala_maven/ScalaRunMojo.java
+++ b/src/main/java/scala_maven/ScalaRunMojo.java
@@ -1,5 +1,6 @@
 package scala_maven;
 
+import org.apache.maven.toolchain.Toolchain;
 import org.codehaus.plexus.util.StringUtils;
 
 import scala_maven_executions.JavaMainCaller;
@@ -70,19 +71,20 @@ public class ScalaRunMojo extends ScalaMojoSupport {
     @SuppressWarnings("unchecked")
     protected void doExecute() throws Exception {
         JavaMainCaller jcmd = null;
+        Toolchain toolchain = toolchainManager.getToolchainFromBuildContext("jdk", session);
         if (StringUtils.isNotEmpty(mainClass)) {
-            jcmd = new JavaMainCallerByFork(this, mainClass, MainHelper.toMultiPath(project.getTestClasspathElements()), jvmArgs, args, forceUseArgFile);
+            jcmd = new JavaMainCallerByFork(this, mainClass, MainHelper.toMultiPath(project.getTestClasspathElements()), jvmArgs, args, forceUseArgFile, toolchain);
         } else if ((launchers != null) && (launchers.length > 0)) {
             if (StringUtils.isNotEmpty(launcher)) {
                 for(int i = 0; (i < launchers.length) && (jcmd == null); i++) {
                     if (launcher.equals(launchers[i].id)) {
                         getLog().info("launcher '"+ launchers[i].id + "' selected => "+ launchers[i].mainClass );
-                        jcmd = new JavaMainCallerByFork(this, launchers[i].mainClass, MainHelper.toMultiPath(project.getTestClasspathElements()), launchers[i].jvmArgs, launchers[i].args, forceUseArgFile);
+                        jcmd = new JavaMainCallerByFork(this, launchers[i].mainClass, MainHelper.toMultiPath(project.getTestClasspathElements()), launchers[i].jvmArgs, launchers[i].args, forceUseArgFile, toolchain);
                     }
                 }
             } else {
                 getLog().info("launcher '"+ launchers[0].id + "' selected => "+ launchers[0].mainClass );
-                jcmd = new JavaMainCallerByFork(this, launchers[0].mainClass, MainHelper.toMultiPath(project.getTestClasspathElements()), launchers[0].jvmArgs, launchers[0].args, forceUseArgFile);
+                jcmd = new JavaMainCallerByFork(this, launchers[0].mainClass, MainHelper.toMultiPath(project.getTestClasspathElements()), launchers[0].jvmArgs, launchers[0].args, forceUseArgFile, toolchain);
             }
         }
         if (jcmd != null) {

--- a/src/main/java/scala_maven_model/MavenProjectAdapter.java
+++ b/src/main/java/scala_maven_model/MavenProjectAdapter.java
@@ -29,6 +29,7 @@ import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginManagement;
 import org.apache.maven.model.Prerequisites;
 import org.apache.maven.model.Profile;
+import org.apache.maven.model.ReportPlugin;
 import org.apache.maven.model.Reporting;
 import org.apache.maven.model.Repository;
 import org.apache.maven.model.Resource;
@@ -184,7 +185,7 @@ public class MavenProjectAdapter {
     }
 
 
-    public List<Plugin> getReportPlugins() {
+    public List<ReportPlugin> getReportPlugins() {
         return wrapped.getReportPlugins();
     }
 
@@ -483,10 +484,6 @@ public class MavenProjectAdapter {
         wrapped.addMailingList(mailingList);
     }
 
-    public void addPlugin(Plugin plugin) {
-        wrapped.addPlugin(plugin);
-    }
-
     public void addProjectReference(MavenProject project) {
         wrapped.addProjectReference(project);
     }
@@ -669,10 +666,6 @@ public class MavenProjectAdapter {
         return wrapped.hasParent();
     }
 
-    public void injectPluginManagementInfo(Plugin arg0) {
-        wrapped.injectPluginManagementInfo(arg0);
-    }
-
     public boolean isExecutionRoot() {
         return wrapped.isExecutionRoot();
     }
@@ -804,10 +797,6 @@ public class MavenProjectAdapter {
 
     public void setPluginArtifactRepositories(List pluginArtifactRepositories) {
         wrapped.setPluginArtifactRepositories(pluginArtifactRepositories);
-    }
-
-    public void setPluginArtifacts(Set pluginArtifacts) {
-        wrapped.setPluginArtifacts(pluginArtifacts);
     }
 
     public void setReleaseArtifactRepository(


### PR DESCRIPTION
Maven has a [toolchain API](http://maven.apache.org/ref/3.0.4/maven-core/apidocs/org/apache/maven/toolchain/package-summary.html) ([sources](http://svn.apache.org/viewvc/maven/maven-3/tags/maven-3.0.4/maven-core/src/main/java/org/apache/maven/toolchain/)) that can be used to locate JDK tools, including the `java` launcher that's being used to run the Scala compiler.

This changes `scala-maven-plugin` to compile against Maven 3.0, and adds support for the toolchain API. If a project uses the `maven-toolchains-plugin` to select a specific JDK, `scala-maven-plugin` will use it instead of the JDK that Maven was run with. If the project doesn't configure a JDK with the `maven-toolchains-plugin`, the `java.home` system property is used as usual.

There are a few other changes that I needed to make to get `scala-maven-plugin` to build against Maven 3.0. I had to use `maven-artifact` 2.2.1 because of a couple of classes that were removed in 3.0, but this seems to work anyway.
