### PR TITLE
Add javac args for incremental compiler

### DIFF
--- a/src/main/java/scala_maven/ScalaCompilerSupport.java
+++ b/src/main/java/scala_maven/ScalaCompilerSupport.java
@@ -225,21 +225,24 @@ public abstract class ScalaCompilerSupport extends ScalaSourceMojoSupport {
     }
 
     protected int incrementalCompile(List<String> classpathElements, List<File> sourceRootDirs, File outputDir, File cacheFile) throws Exception, InterruptedException {
-        String scalaVersion = findScalaVersion().toString();
-        File libraryJar = getLibraryJar();
-        File compilerJar = getCompilerJar();
-        String sbtGroupId = SbtIncrementalCompiler.SBT_GROUP_ID;
-        String xsbtiArtifactId = SbtIncrementalCompiler.XSBTI_ARTIFACT_ID;
-        String compilerInterfaceArtifactId = SbtIncrementalCompiler.COMPILER_INTERFACE_ARTIFACT_ID;
-        String compilerInterfaceClassifier = SbtIncrementalCompiler.COMPILER_INTERFACE_CLASSIFIER;
-        String sbtVersion = findVersionFromPluginArtifacts(sbtGroupId, SbtIncrementalCompiler.COMPILER_INTEGRATION_ARTIFACT_ID);
-        File xsbtiJar = getPluginArtifactJar(sbtGroupId, xsbtiArtifactId, sbtVersion);
-        File interfaceSrcJar = getPluginArtifactJar(sbtGroupId, compilerInterfaceArtifactId, sbtVersion, compilerInterfaceClassifier);
-        if (incremental == null) incremental = new SbtIncrementalCompiler(scalaVersion, libraryJar, compilerJar, sbtVersion, xsbtiJar, interfaceSrcJar, residentCompilerLimit, getLog());
+        if (incremental == null) {
+            String scalaVersion = findScalaVersion().toString();
+            File libraryJar = getLibraryJar();
+            File compilerJar = getCompilerJar();
+            String sbtGroupId = SbtIncrementalCompiler.SBT_GROUP_ID;
+            String xsbtiArtifactId = SbtIncrementalCompiler.XSBTI_ARTIFACT_ID;
+            String compilerInterfaceArtifactId = SbtIncrementalCompiler.COMPILER_INTERFACE_ARTIFACT_ID;
+            String compilerInterfaceClassifier = SbtIncrementalCompiler.COMPILER_INTERFACE_CLASSIFIER;
+            String sbtVersion = findVersionFromPluginArtifacts(sbtGroupId, SbtIncrementalCompiler.COMPILER_INTEGRATION_ARTIFACT_ID);
+            File xsbtiJar = getPluginArtifactJar(sbtGroupId, xsbtiArtifactId, sbtVersion);
+            File interfaceSrcJar = getPluginArtifactJar(sbtGroupId, compilerInterfaceArtifactId, sbtVersion, compilerInterfaceClassifier);
+            incremental = new SbtIncrementalCompiler(scalaVersion, libraryJar, compilerJar, sbtVersion, xsbtiJar, interfaceSrcJar, residentCompilerLimit, getLog());
+        }
         List<File> sources = findSourceWithFilters(sourceRootDirs);
         List<String> scalacOptions = getScalaOptions();
+        List<String> javacOptions = getJavacOptions();
         Map<File, File> cacheMap = getAnalysisCacheMap();
-        incremental.compile(classpathElements, sources, outputDir, scalacOptions, new ArrayList<String>(), cacheFile, cacheMap);
+        incremental.compile(classpathElements, sources, outputDir, scalacOptions, javacOptions, cacheFile, cacheMap);
         return 1;
     }
 

--- a/src/main/java/scala_maven/ScalaMojoSupport.java
+++ b/src/main/java/scala_maven/ScalaMojoSupport.java
@@ -179,6 +179,21 @@ public abstract class ScalaMojoSupport extends AbstractMojo {
     private String scalaVersion;
 
     /**
+     * Arguments for javac (when using incremental compiler).
+     *
+     * @parameter expression="${javacArgs}"
+     */
+    protected String[] javacArgs;
+
+    /**
+     * Alternative method for specifying javac arguments (when using incremental compiler).
+     * Can be used from command line with -DaddJavacArgs=arg1|arg2|arg3|... rather than in pom.xml.
+     *
+     * @parameter expression="${addJavacArgs}"
+     */
+    protected String addJavacArgs;
+
+    /**
      * Display the command line called ?
      * (property 'maven.scala.displayCmd' replaced by 'displayCmd')
      *
@@ -560,6 +575,15 @@ public abstract class ScalaMojoSupport extends AbstractMojo {
             Collections.addAll(options, StringUtils.split(addScalacArgs, "|"));
         }
         options.addAll(getCompilerPluginOptions());
+        return options;
+    }
+
+    protected List<String> getJavacOptions() throws Exception {
+        List<String> options = new ArrayList<String>();
+        if (javacArgs != null) Collections.addAll(options, javacArgs);
+        if (StringUtils.isNotEmpty(addJavacArgs)) {
+            Collections.addAll(options, StringUtils.split(addJavacArgs, "|"));
+        }
         return options;
     }
 


### PR DESCRIPTION
Just realised that there were no javac options being passed to the incremental compiler. This adds it with some extra configuration in the plugin. If there's an easy way to get the javac options for the compiler plugin, that could be better.
