### PR TITLE
Use -C instead of -J for passing javac options to zinc

### DIFF
--- a/src/main/java/sbt_inc/SbtIncrementalCompiler.java
+++ b/src/main/java/sbt_inc/SbtIncrementalCompiler.java
@@ -96,7 +96,7 @@ public class SbtIncrementalCompiler {
             arguments.add("-S" + scalacOption);
         }
         for (String javacOption : javacOptions) {
-            arguments.add("-J" + javacOption);
+            arguments.add("-C" + javacOption);
         }
         arguments.add("-compile-order");
         arguments.add(compileOrder);


### PR DESCRIPTION
Since 0.2.0 zinc uses `-J-<option>` for JVM options and `-C-<option>` for javac option. See typesafehub/zinc@1353ac4c40fbfa81020bd17e6b1652475d748605
