### PR TITLE
Log only to INFO level when no sources to compile found

### DIFF
--- a/src/main/java/scala_maven/ScalaCompilerSupport.java
+++ b/src/main/java/scala_maven/ScalaCompilerSupport.java
@@ -99,7 +99,7 @@ public abstract class ScalaCompilerSupport extends ScalaSourceMojoSupport {
         int nbFiles = compile(getSourceDirectories(), outputDir, analysisCacheFile, getClasspathElements(), false);
         switch (nbFiles) {
             case -1:
-                getLog().warn("No source files found.");
+                getLog().info("No sources to compile");
                 break;
             case 0:
                 getLog().info("Nothing to compile - all classes are up to date");;

--- a/src/main/java/scala_maven/ScalaDocMojo.java
+++ b/src/main/java/scala_maven/ScalaDocMojo.java
@@ -327,7 +327,7 @@ public class ScalaDocMojo extends ScalaSourceMojoSupport implements MavenReport 
     public void generate(Sink sink, Locale locale) throws MavenReportException {
         try {
             if (!canGenerateReport()) {
-                getLog().warn("No source files found");
+                getLog().info("No source files found");
                 return;
             }
 


### PR DESCRIPTION
This prevents warning when you have scala-maven-plugin configuration in the root of multi-module project which has scala sources only in some submodules.

This also corresponds to the behavior of the maven-compiler-plugin.
