### PR TITLE
Prerequisite Maven version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ The **scala-maven-plugin** (previously maven-scala-plugin) is used for compiling
 
 Currently, you need Maven 3.x to build the plugin, create the site, and run `integration-test`.
 
+An existing installation of Scala is also tested against.
+Supposing the scala-library.jar of your existing scala library lives
+at `/usr/local/Cellar/scala/2.10.2/libexec` then you will need to set a symbolic link up as
+follows (on Unix):
+
+`ln -s /usr/local/Cellar/scala/2.10.2/libexec ~/bin/soft-jvm/scala
+
 ## commands
 
 * `mvn package` : generate jar

--- a/pom.xml
+++ b/pom.xml
@@ -84,10 +84,13 @@
     <contributor>
       <name>Shai Yallin</name>
     </contributor>
+    <contributor>
+      <name>Christopher Hunt</name>
+    </contributor>
   </contributors>
 
   <properties>
-    <maven.version>3.0.4</maven.version>
+    <maven.version>3.1.0</maven.version>
     <maven.reporting.version>3.0</maven.reporting.version>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
@@ -96,7 +99,7 @@
   </properties>
 
   <prerequisites>
-    <maven>${maven.version}</maven>
+    <maven>3</maven>
   </prerequisites>
 
   <dependencies>


### PR DESCRIPTION
Any reason why the pre-requisite version of Maven is 3.0.4? 3.1.0 has been out for a while...
