### PR TITLE
Fixes for classpath handling for scala script.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,12 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>${maven.version}</version>
-      <scope>provided</scope>
+    </dependency>
+    <dependency>
+        <!-- Need this because some needed classes were removed from maven-artifact 3.0 -->
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-artifact</artifactId>
+        <version>2.2.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.reporting</groupId>
@@ -127,12 +132,6 @@
       <version>1.1</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-artifact</artifactId>
-      <!-- Need this because some needed classes were removed from maven-artifact 3.0 -->
-      <version>2.2.1</version>
-    </dependency>
-     <dependency>
        <groupId>org.codehaus.plexus</groupId>
        <artifactId>plexus-utils</artifactId>
        <version>3.0</version>


### PR DESCRIPTION
When constructing class:
1. Take dependency management into account. Use maven's transient dependency traverse methods.
2. Avoid different jar versions in the class path (porject's pom ones win, otherwise newer one wins).
3. Don't fail with LinkageError exception for org/codehaus/plexus/

classpath before this patch:
[DEBUG] classpath entry for running and compiling scripts: /home/akshaal/.m2/repository/org/apache/maven/maven-artifact/2.0.6/maven-artifact-2.0.6.jar
[DEBUG] classpath entry for running and compiling scripts: /home/akshaal/.m2/repository/org/apache/maven/maven-artifact/2.0.8/maven-artifact-2.0.8.jar
[DEBUG] classpath entry for running and compiling scripts: /home/akshaal/.m2/repository/org/apache/maven/maven-artifact/2.2.1/maven-artifact-2.2.1.jar
[DEBUG] classpath entry for running and compiling scripts: /home/akshaal/.m2/repository/org/apache/maven/maven-artifact/3.0.4/maven-artifact-3.0.4.jar
[DEBUG] classpath entry for running and compiling scripts: /home/akshaal/.m2/repository/org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.jar
[DEBUG] classpath entry for running and compiling scripts: /home/akshaal/.m2/repository/org/apache/maven/maven-core/3.0.4/maven-core-3.0.4.jar
[DEBUG] classpath entry for running and compiling scripts: /home/akshaal/.m2/repository/classworlds/classworlds/1.1-alpha-2/classworlds-1.1-alpha-2.jar
[DEBUG] classpath entry for running and compiling scripts: /home/akshaal/.m2/repository/classworlds/classworlds/1.1/classworlds-1.1.jar
......

classpath after this patch:
[DEBUG] classpath entry for running and compiling scripts: /home/akshaal/.m2/repository/org/apache/maven/maven-artifact/2.2.1/maven-artifact-2.2.1.jar
[DEBUG] classpath entry for running and compiling scripts: /home/akshaal/.m2/repository/org/apache/maven/maven-core/3.0.4/maven-core-3.0.4.jar
[DEBUG] classpath entry for running and compiling scripts: /home/et1055/.m2/repository/classworlds/classworlds/1.1-alpha-2/classworlds-1.1-alpha-2.jar
.....

Also fixes:
Failed to execute goal net.alchim31.maven:scala-maven-plugin:3.1.6:script (default-cli) on project blahblahblah:
wrap: java.lang.Exception: A LinkageError exception was thrown: loader constraint violation: when resolving interface
method "org.apache.maven.shared.invoker.InvocationResult.getExecutionException()Lorg/codehaus/plexus/util/cli/CommandLineException;"
     the class loader (instance of org/codehaus/plexus/classworlds/realm/ClassRealm) of the current class, CommonMavenHelper,
 and the class loader (instance of org/codehaus/plexus/classworlds/realm/ClassRealm) for resolved class,
  org/apache/maven/shared/invoker/InvocationResult, have different Class objects for the type
      org/codehaus/plexus/util/cli/CommandLineException used in the signature -> [Help 1]
