### PR TITLE
Use proper version of jline for supporting scala:console goal with Scala 2.11

### DIFF
--- a/src/main/java/scala_maven/ScalaConsoleMojo.java
+++ b/src/main/java/scala_maven/ScalaConsoleMojo.java
@@ -61,7 +61,8 @@ public class ScalaConsoleMojo extends ScalaMojoSupport {
         addCompilerToClasspath(classpath);
         addLibraryToClasspath(classpath);
         if (new VersionNumber("2.11.0").compareTo(scalaVersion) <= 0) {
-          addToClasspath("jline", "jline", scalaVersion.toString(), classpath);
+          String version = scalaVersion.major + "." + scalaVersion.minor;
+          addToClasspath("jline", "jline", version, classpath);
         } else if (new VersionNumber("2.9.0").compareTo(scalaVersion) <= 0) {
           addToClasspath("org.scala-lang", "jline", scalaVersion.toString(), classpath);
         } else {


### PR DESCRIPTION
Scala switched to using the stock jline, so the artifact needs to change. I'm not totally sure the version number will be correct for versions past 2.11 as I'm not sure that jline's versions are pinned to scala's, even though they presently match.
