### PR TITLE
Jline version fix.

### DIFF
--- a/src/main/java/scala_maven/ScalaConsoleMojo.java
+++ b/src/main/java/scala_maven/ScalaConsoleMojo.java
@@ -61,8 +61,7 @@ public class ScalaConsoleMojo extends ScalaMojoSupport {
         addCompilerToClasspath(classpath);
         addLibraryToClasspath(classpath);
         if (new VersionNumber("2.11.0").compareTo(scalaVersion) <= 0) {
-          String version = scalaVersion.major + "." + scalaVersion.minor;
-          addToClasspath("jline", "jline", version, classpath);
+            addToClasspath("jline", "jline", "2.12", classpath);
         } else if (new VersionNumber("2.9.0").compareTo(scalaVersion) <= 0) {
           addToClasspath("org.scala-lang", "jline", scalaVersion.toString(), classpath);
         } else {


### PR DESCRIPTION
The correct version for jline is not 2.11 but 2.12.
See: http://mvnrepository.com/artifact/org.scala-lang/scala-compiler/2.11.2
