### PR TITLE
Update ScalaContinuousTestMojo.java

### DIFF
--- a/src/main/java/scala_maven/ScalaContinuousTestMojo.java
+++ b/src/main/java/scala_maven/ScalaContinuousTestMojo.java
@@ -36,7 +36,7 @@ public class ScalaContinuousTestMojo extends ScalaContinuousCompileMojo {
      * repository like <code>${project.build.directory}/it-repo</code>. Otherwise, your ordinary local repository will
      * be used, potentially soiling it with broken artifacts.
      *
-     * @parameter property="invoker.localRepositoryPath" default-value="${settings.localRepository"
+     * @parameter property="${invoker.localRepositoryPath}" default-value="${settings.localRepository}"
      */
     protected File localRepositoryPath;
 

--- a/src/main/java/scala_maven/ScalaContinuousTestMojo.java
+++ b/src/main/java/scala_maven/ScalaContinuousTestMojo.java
@@ -36,7 +36,7 @@ public class ScalaContinuousTestMojo extends ScalaContinuousCompileMojo {
      * repository like <code>${project.build.directory}/it-repo</code>. Otherwise, your ordinary local repository will
      * be used, potentially soiling it with broken artifacts.
      *
-     * @parameter property="invoker.localRepositoryPath}" default-value="${settings.localRepository"
+     * @parameter property="invoker.localRepositoryPath" default-value="${settings.localRepository"
      */
     protected File localRepositoryPath;
 


### PR DESCRIPTION
Appeared to be invalid Mojo @property definition which was causing the following error when running cctest :

[ERROR] Failed to execute goal net.alchim31.maven:scala-maven-plugin:3.2.2:cctest (default-cli) on project pcd-quality-control: Execution default-cli of goal net.alchim31.maven:scala-maven-plugin:3.2.2:cctest failed: Local repository location: '/Users/medge/workspace/pcd-quality-control/${invoker.localRepositoryPath}}' is NOT a directory. -> [Help 1]