### PR TITLE
Make it possible to deactivate `integration-tests` profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -404,7 +404,6 @@
     <profile>
       <id>integration-tests</id>
       <activation>
-          <activeByDefault>true</activeByDefault>
         <property>
           <name>maven.test.skip</name>
           <value>!true</value>


### PR DESCRIPTION
Problem:

`integration-tests` profile has two activations: `activeByDefault` and `maven.tests.skip!=true`. Maven activates a profile when at least one activation condition is true. Thus this profile will be active regardless of the `maven.tests.skip` property.

Solution:

Remove `activeByDefault` section. `maven.tests.skip!=true` is enough.
