### PR TITLE
Improve test failure message for wrong JDK (> 7).

### DIFF
--- a/src/test/java/scala_maven/MiscTest.java
+++ b/src/test/java/scala_maven/MiscTest.java
@@ -24,7 +24,7 @@ import org.codehaus.plexus.util.StringUtils;
  */
 public class MiscTest extends TestCase {
     public void testJdkSplit() throws Exception {
-        assertEquals(6, "hello".split("|").length);
+        assertEquals("Are you using JDK > 7? This failure is expected above JDK 7.", 6, "hello".split("|").length);
         assertEquals(1, "hello".split("\\|").length);
         assertEquals(2, "hel|lo".split("\\|").length);
         assertEquals(3, "hel||lo".split("\\|").length);


### PR DESCRIPTION
This is related to this issue: #186

Also, if interested, I could create a PR that included a Maven Enforcer Rule to fail the build sooner.