### PR TITLE
Upgrade maven-site-plugin in ITs to 3.3 so that ITs pass with Maven 3.3.3

### DIFF
--- a/src/it/includesExcludes/pom.xml
+++ b/src/it/includesExcludes/pom.xml
@@ -43,7 +43,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.0</version>
+        <version>3.3</version>
         <configuration>
           <reportPlugins>
             <plugin>

--- a/src/it/off-test_scaladoc2_onMultiModules/pom.xml
+++ b/src/it/off-test_scaladoc2_onMultiModules/pom.xml
@@ -42,7 +42,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-site-plugin</artifactId>
-				<version>3.0</version>
+				<version>3.3</version>
 				<configuration>
 					<reportPlugins>
 						<plugin>

--- a/src/it/test1/pom.xml
+++ b/src/it/test1/pom.xml
@@ -75,7 +75,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.0</version>
+        <version>3.3</version>
         <configuration>
           <reportPlugins>
             <plugin>

--- a/src/it/test_custom_outputdir/pom.xml
+++ b/src/it/test_custom_outputdir/pom.xml
@@ -73,7 +73,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.0</version>
+        <version>3.3</version>
         <configuration>
           <reportPlugins>
             <plugin>

--- a/src/it/test_goal_site/pom.xml
+++ b/src/it/test_goal_site/pom.xml
@@ -40,7 +40,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.0</version>
+        <version>3.3</version>
         <configuration>
           <reportPlugins>
             <plugin>

--- a/src/it/test_scalaHome/pom.xml
+++ b/src/it/test_scalaHome/pom.xml
@@ -32,7 +32,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.0</version>
+        <version>3.3</version>
         <configuration>
           <reportPlugins>
             <plugin>


### PR DESCRIPTION
Tested by running mvn integration-test, which failed without these
changes.

See
https://cwiki.apache.org/confluence/display/MAVEN/AetherClassNotFound
for details on what this upgrade does and what was broken when I ran
the ITs.
