### PR TITLE
Zinc - Toolchains support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
     <dependency>
       <groupId>com.typesafe.zinc</groupId>
       <artifactId>zinc</artifactId>
-      <version>0.3.5</version>
+      <version>0.3.9</version>
     </dependency>
 <!--
     <dependency>

--- a/src/main/java/scala_maven/ScalaCompilerSupport.java
+++ b/src/main/java/scala_maven/ScalaCompilerSupport.java
@@ -300,7 +300,7 @@ public abstract class ScalaCompilerSupport extends ScalaSourceMojoSupport {
         Map<File, File> cacheMap = getAnalysisCacheMap();
 
         try {
-            incremental.compile(project.getBasedir(), classpathElements, sources, outputDir, scalacOptions, javacOptions, cacheFile, cacheMap, compileOrder);
+            incremental.compile(project.getBasedir(), classpathElements, sources, outputDir, scalacOptions, javacOptions, cacheFile, cacheMap, compileOrder, toolchainManager.getToolchainFromBuildContext("jdk", session));
         } catch (xsbti.CompileFailed e) {
             if (compileInLoop) {
                 compileErrors = true;

--- a/src/main/java/scala_maven_executions/JavaMainCallerByFork.java
+++ b/src/main/java/scala_maven_executions/JavaMainCallerByFork.java
@@ -17,7 +17,7 @@ import org.apache.maven.toolchain.Toolchain;
 import org.codehaus.plexus.util.StringUtils;
 
 import scala_maven_executions.LogProcessorUtils.LevelState;
-import util.JavaHomeLocator;
+import util.JavaLocator;
 
 /**
  * forked java commands.
@@ -42,7 +42,7 @@ public class JavaMainCallerByFork extends JavaMainCallerSupport {
             env.add(key + "=" + System.getenv(key));
         }
 
-        _javaExec = JavaHomeLocator.fromToolchain(toolchain);
+        _javaExec = JavaLocator.findExecutableFromToolchain(toolchain);
         _forceUseArgFile = forceUseArgFile;
     }
 

--- a/src/main/java/scala_maven_executions/JavaMainCallerByFork.java
+++ b/src/main/java/scala_maven_executions/JavaMainCallerByFork.java
@@ -17,6 +17,7 @@ import org.apache.maven.toolchain.Toolchain;
 import org.codehaus.plexus.util.StringUtils;
 
 import scala_maven_executions.LogProcessorUtils.LevelState;
+import util.JavaHomeLocator;
 
 /**
  * forked java commands.
@@ -41,19 +42,7 @@ public class JavaMainCallerByFork extends JavaMainCallerSupport {
             env.add(key + "=" + System.getenv(key));
         }
 
-        if (toolchain != null)
-            _javaExec = toolchain.findTool("java");
-
-        if (toolchain == null || _javaExec == null) {
-            _javaExec = System.getProperty("java.home");
-            if (_javaExec == null) {
-                _javaExec = System.getenv("JAVA_HOME");
-                if (_javaExec == null) {
-                    throw new IllegalStateException("Couldn't locate java, try setting JAVA_HOME environment variable.");
-                }
-            }
-            _javaExec += File.separator + "bin" + File.separator + "java";
-        }
+        _javaExec = JavaHomeLocator.fromToolchain(toolchain);
         _forceUseArgFile = forceUseArgFile;
     }
 

--- a/src/main/java/util/JavaHomeLocator.java
+++ b/src/main/java/util/JavaHomeLocator.java
@@ -1,0 +1,34 @@
+package util;
+
+import org.apache.maven.toolchain.Toolchain;
+
+import java.io.File;
+
+/**
+ * Utilities to aid with finding Java's location
+ *
+ * @Author C. Dessonville
+ */
+public class JavaHomeLocator {
+
+  public static String fromToolchain(Toolchain toolchain) {
+    String _javaExec = null;
+
+    if (toolchain != null)
+      _javaExec = toolchain.findTool("java");
+
+    if (toolchain == null || _javaExec == null) {
+      _javaExec = System.getProperty("java.home");
+      if (_javaExec == null) {
+        _javaExec = System.getenv("JAVA_HOME");
+        if (_javaExec == null) {
+          throw new IllegalStateException("Couldn't locate java, try setting JAVA_HOME environment variable.");
+        }
+      }
+
+      _javaExec += File.separator + "bin" + File.separator + "java";
+    }
+
+    return _javaExec;
+  }
+}

--- a/src/main/java/util/JavaLocator.java
+++ b/src/main/java/util/JavaLocator.java
@@ -9,9 +9,9 @@ import java.io.File;
  *
  * @Author C. Dessonville
  */
-public class JavaHomeLocator {
+public class JavaLocator {
 
-  public static String fromToolchain(Toolchain toolchain) {
+  public static String findExecutableFromToolchain(Toolchain toolchain) {
     String _javaExec = null;
 
     if (toolchain != null)

--- a/src/main/java/util/JavaLocator.java
+++ b/src/main/java/util/JavaLocator.java
@@ -31,4 +31,18 @@ public class JavaLocator {
 
     return _javaExec;
   }
+
+  public static String findHomeFromToolchain(Toolchain toolchain) {
+    String executable = findExecutableFromToolchain(toolchain);
+    if (executable != null) {
+      File executableParent = new File(executable).getParentFile();
+      if (executableParent != null) {
+        return executableParent.getParent();
+      } else {
+        return null;
+      }
+    } else {
+      return null;
+    }
+  }
 }


### PR DESCRIPTION
I was hitting an issue where Zinc was using Java 7 (which was what launched Maven,) despite toolchains specifying Java 8.  This change has us look up the desired Java version through a few steps of resolution, and then passes that to Zinc.

The ITs passed, though I had to also have https://github.com/davidB/scala-maven-plugin/pull/190 for them to pass locally.  Ideally I would merge https://github.com/davidB/scala-maven-plugin/pull/190 first to avoid mistakes.
