### PR TITLE
Use `maven-compat` for the Maven 2 features.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,11 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.maven</groupId>
+      <artifactId>maven-compat</artifactId>
+      <version>${maven.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>${maven.version}</version>
       <scope>provided</scope>
@@ -127,12 +132,6 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-exec</artifactId>
       <version>1.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-artifact</artifactId>
-      <!-- Need this because some needed classes were removed from maven-artifact 3.0 -->
-      <version>2.2.1</version>
     </dependency>
      <dependency>
        <groupId>org.codehaus.plexus</groupId>

--- a/src/main/java/scala_maven/ScalaMojoSupport.java
+++ b/src/main/java/scala_maven/ScalaMojoSupport.java
@@ -110,7 +110,7 @@ public abstract class ScalaMojoSupport extends AbstractMojo {
      * @readonly
      * @required
      */
-    protected List<?> remoteRepos;
+    protected List<ArtifactRepository> remoteRepos;
 
     /**
      * Additional dependencies/jar to add to classpath to run "scalaClassName" (scope and optional field not supported)
@@ -204,7 +204,7 @@ public abstract class ScalaMojoSupport extends AbstractMojo {
      * @parameter property="scala.compat.version"
      */
     private String scalaCompatVersion;
-    
+
     /**
      * Path to Scala installation to use instead of the artifact (define as dependencies).
      *
@@ -237,28 +237,28 @@ public abstract class ScalaMojoSupport extends AbstractMojo {
      */
     protected String addJavacArgs;
 
-    
+
     /**
      * The -source argument for the Java compiler (when using incremental compiler).
      *
      * @parameter property="maven.compiler.source"
      */
     protected String source;
-    
+
     /**
      * The -target argument for the Java compiler (when using incremental compiler).
      *
      * @parameter property="maven.compiler.target"
      */
     protected String target;
-    
+
     /**
      * The -encoding argument for the Java compiler. (when using incremental compiler).
      *
      * @parameter property="project.build.sourceEncoding" default-value="UTF-8"
      */
     protected String encoding;
-    
+
     /**
      * Display the command line called ?
      * (property 'maven.scala.displayCmd' replaced by 'displayCmd')
@@ -638,7 +638,7 @@ public abstract class ScalaMojoSupport extends AbstractMojo {
     }
 
     protected JavaMainCaller getEmptyScalaCommand(String mainClass) throws Exception {
-      
+
       //TODO - Fork or not depending on configuration?
       JavaMainCaller cmd;
       String toolcp = getToolClasspath();


### PR DESCRIPTION
* `pom.xml`
  * Added `maven-compat` dependency which allows to usage of Maven 2 features
    with Maven 3.
  * Removed Maven 2 dependency.
* `src/main/java/scala_maven/ScalaMojoSupport.java`
  * Removed wildcard type that was used for the Maven 2 dependency that was
    removed. Replaced it with the correct generic type, as required by
    `maven-compat`.