### PR TITLE
Fix scala console212

### DIFF
--- a/src/main/java/scala_maven/ScalaConsoleMojo.java
+++ b/src/main/java/scala_maven/ScalaConsoleMojo.java
@@ -1,7 +1,9 @@
 package scala_maven;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -9,6 +11,8 @@ import java.util.Set;
 import scala_maven_executions.JavaMainCaller;
 import scala_maven_executions.JavaMainCallerInProcess;
 import scala_maven_executions.MainHelper;
+
+import org.apache.maven.artifact.Artifact;
 
 /**
  * Run the Scala console with all the classes of the projects (dependencies and builded)
@@ -20,6 +24,22 @@ import scala_maven_executions.MainHelper;
  * @executionStrategy once-per-session
  */
 public class ScalaConsoleMojo extends ScalaMojoSupport {
+
+    // Private Static Values //
+
+    /**
+     * Constant {@link String} for "jline". Used for the artifact id, and
+     * usually the group id, for the JLine library needed by the Scala Console.
+     */
+    private static final String JLINE = "jline";
+
+    /**
+     * Constant {@link String} for "org.scala-lang". In this class it is used
+     * for the forked JLine group id.
+     */
+    private static final String SCALA_ORG_GROUP = "org.scala-lang";
+
+    // Instance Members //
 
     /**
      * The console to run.
@@ -55,50 +75,243 @@ public class ScalaConsoleMojo extends ScalaMojoSupport {
 
     @Override
     protected void doExecute() throws Exception {
-        //TODO - Many other paths uses the getScalaCommand()!!! We should try to use that as much as possibel to help maintainability.
-        VersionNumber scalaVersion = findScalaVersion();
-        Set<String> classpath = new LinkedHashSet<String>();
-        addCompilerToClasspath(classpath);
-        addLibraryToClasspath(classpath);
-        if (new VersionNumber("2.11.0").compareTo(scalaVersion) <= 0) {
-            addToClasspath("jline", "jline", "2.12", classpath);
-        } else if (new VersionNumber("2.9.0").compareTo(scalaVersion) <= 0) {
-          addToClasspath("org.scala-lang", "jline", scalaVersion.toString(), classpath);
-        } else {
-          addToClasspath("jline", "jline", "0.9.94", classpath);
-        }
-        classpath.addAll(project.getCompileClasspathElements());
-        if (useTestClasspath) {
-            classpath.addAll(project.getTestClasspathElements());
-        }
-        if (useRuntimeClasspath) {
-            classpath.addAll(project.getRuntimeClasspathElements());
-        }
-        String classpathStr = MainHelper.toMultiPath(classpath.toArray(new String[classpath.size()]));
-        JavaMainCaller jcmd = null;
-        List<String> list = new ArrayList<String>(args != null ? args.length + 3 : 3);
-        if(args != null) {
-            for(String arg : args) {
-                list.add(arg);
-            }
-        }
-        list.add("-cp");
-        list.add(classpathStr);
+        // Force no forking
+        final JavaMainCaller jcmd = super.getScalaCommand(false, this.mainConsole);
+        // Determine Scala Version
+        final VersionNumber scalaVersion = super.findScalaVersion();
+        final Set<String> classpath = this.setupClassPathForConsole(scalaVersion);
 
-        if(fork) {
-            getLog().warn("scala-maven-plugin cannot fork scala console!!  Running in process");
+        // Log if we are violating the user settings.
+        if (super.fork) {
+            super.getLog().info("Ignoring fork for console execution.");
         }
 
-        jcmd = new JavaMainCallerInProcess(this, mainConsole, classpathStr, jvmArgs, list.toArray(new String[list.size()]));
-        //We need to make sure compiler plugins are sent into the interpreter as well!
-        addCompilerPluginOptions(jcmd);
-        if (javaRebelPath != null) {
-            if (!javaRebelPath.exists()) {
-                getLog().warn("javaRevelPath '"+javaRebelPath.getCanonicalPath()+"' not found");
+        // Setup the classpath
+
+
+        // Build the classpath string.
+        final String classpathStr = MainHelper.toMultiPath(classpath.toArray(new String[classpath.size()]));
+
+        // Setup the JavaMainCaller
+        jcmd.addArgs(super.args);
+        jcmd.addOption("-cp", classpathStr);
+        super.addCompilerPluginOptions(jcmd);
+
+        // Check for Java Rebel
+        this.handleJavaRebel(jcmd);
+
+        // Run
+        jcmd.run(super.displayCmd);
+    }
+
+    // Private Methods //
+
+    /**
+     * If {@link #javaRebelPath} is defined, then attempt to resolve it on the
+     * filesystem and setup the Scala console to use it.
+     * <p>
+     * If we are unable to find it or {@link #javaRebelPath} is {@code null},
+     * then nothing is done to the given {@link JavaMainCaller}.
+     *
+     * @param jcmd the {@link JavaMainCaller} to which to add the JRebel settings.
+     */
+    private void handleJavaRebel(final JavaMainCaller jcmd) throws IOException {
+        if (this.javaRebelPath != null) {
+            final String canonicalJavaRebelPath = this.javaRebelPath.getCanonicalPath();
+            if (this.javaRebelPath.exists()) {
+                jcmd.addJvmArgs("-noverify", String.format("-javaagent:%s", canonicalJavaRebelPath));
             } else {
-                jcmd.addJvmArgs("-noverify", "-javaagent:" + javaRebelPath.getCanonicalPath());
+                super.getLog().warn(String.format("javaRevelPath '%s' not found", canonicalJavaRebelPath));
             }
         }
-        jcmd.run(displayCmd);
+    }
+
+    /**
+     * Construct the appropriate Classpath for the Scala console.
+     *
+     * @param scalaVersion the {@link VersionNumber} for the Scala
+     *                     Compiler/Library we are using.
+     *
+     * @return A {@link Set} of {@link String} defining classpath values to
+     *         provide to the Scala console.
+     *
+     * @throws {@link Exception} for many reasons, mostly relating to ad-hoc
+     *         dependency resolution.
+     */
+    private Set<String> setupClassPathForConsole(final VersionNumber scalaVersion) throws Exception {
+        final Set<String> classpath = new HashSet<String>();
+
+        classpath.addAll(this.setupProjectClasspaths());
+        classpath.addAll(this.setupConsoleClasspaths(scalaVersion));
+
+        return classpath;
+    }
+
+    /**
+     * Construct the Classpath defined by the project and plugin settings.
+     * <p>
+     * This should include the following entities.
+     * <ul>
+     *   <li> Scala Compiler, as defined by {@link ScalaMojoSupport#addCompilerToClasspath}.
+     *   <li> Library Classpath, as defined by {@link ScalaMojoSupport#addLibraryToClasspath}.
+     *   <li> Test Classpath, if {@link #useTestClasspath} is {@code true}.
+     *   <li> Runtime Classpath, if {@link #useRuntimeClasspath} is {@code true}.
+     * </ul>
+     *
+     * @return A {@link Set} of {@link String} defining the classpath for the
+     *         project and plugin settings.
+     *
+     * @throws {@link Exception} for many reasons, mostly relating to ad-hoc
+     *         dependency resolution.
+     */
+    private Set<String> setupProjectClasspaths() throws Exception {
+        final Set<String> classpath = new HashSet<String>();
+
+        super.addCompilerToClasspath(classpath);
+        super.addLibraryToClasspath(classpath);
+
+        if (this.useTestClasspath) {
+            classpath.addAll(super.project.getTestClasspathElements());
+        }
+
+        if (this.useRuntimeClasspath) {
+            classpath.addAll(super.project.getRuntimeClasspathElements());
+        }
+
+        return classpath;
+    }
+
+    /**
+     * Construct the Classpath for any additional dependencies that are needed
+     * to run the Scala console.
+     * <p>
+     * This should include the following entities.
+     * <ul>
+     *   <li> Jline, used for readline like features in the REPL.
+     * </ul>
+     *
+     * @param scalaVersion the version of the Scala Compiler/Library we are
+     *        using for this execution.
+     *
+     * @return A {@link Set} of {@link String} of the classpath as defined by
+     *
+     * @throws {@link Exception} for many reasons, mostly relating to ad-hoc
+     *         dependency resolution.
+     */
+    private Set<String> setupConsoleClasspaths(final VersionNumber scalaVersion) throws Exception {
+        final Set<String> classpath = new HashSet<String>();
+
+        super.addToClasspath(this.resolveJLine(scalaVersion, this.fallbackJLine(scalaVersion)), classpath, true);
+
+        return classpath;
+    }
+
+    /**
+     * Attempt to resolve JLine against the Scala Compiler's dependency tree.
+     * <p>
+     * This allows us to not have to worry about manually keeping the JLine
+     * dependency synchronized with the Scala REPL, which is likely to cause
+     * binary compatibility errors. If, for some reason, we are unable to
+     * resolve this dependency using the Compiler's dependency tree, we fallback
+     * to a set of hard-coded defaults that will <em>usually</em> work, but will
+     * not always work.
+     * <p>
+     * If the dynamic approach to finding the JLine dependency proves stable, we
+     * may drop the fallback in the future.
+     *
+     * @param scalaVersion the version of the Scala Compiler/Library we are
+     *        using for this execution.
+     * @param defaultFallback returned if we are unable to resolve JLine against
+     *        the Scala Compiler's dependency tree.
+     *
+     * @return an {@link Artifact} to provide to the runtime of the Scala
+     *         console conforming the JLine.
+     *
+     * @throws {@link Exception} for many reasons, mostly relating to ad-hoc
+     *         dependency resolution.
+     */
+    private Artifact resolveJLine(final VersionNumber scalaVersion,
+                                  final Artifact defaultFallback) throws Exception {
+        final Artifact compilerArtifact =
+            super.scalaCompilerArtifact(scalaVersion.toString());
+        final Set<Artifact> compilerDeps =
+            super.resolveArtifactDependencies(compilerArtifact);
+        for (final Artifact a : compilerDeps) {
+            super.getLog().warn(a.toString());
+            if (this.filterForJline(a)) {
+                return a;
+            }
+        }
+
+        super.getLog().warn("Unable to determine the required Jline dependency from the POM. Falling back to hard-coded defaults.");
+        super.getLog().warn("If you get an InvocationTargetException, then this probably means we guessed the wrong version for JLine");
+        super.getLog().warn(String.format("Guessed JLine: %s", defaultFallback.toString()));
+
+        return defaultFallback;
+    }
+
+    /**
+     * Helper function to filter a collection of {@link Artifact} for JLine.
+     * <p>
+     * Since different versions of the Scala Compiler were using different
+     * artifacts for JLine, things are a bit tricky here. Any {@link Artifact}
+     * to have an artifact id equal to {@code "jline"} and a group id equal to
+     * <em>either</em> {@code "jline"} or {@code "org.scala-lang"} will yield
+     * {@code true}. The latter group id corresponds to a fork of JLine that is
+     * not being used anymore.
+     *
+     * @param artifact the {@link Artifact} to check to see if it is viable
+     *        JLine candidate.
+     */
+    private boolean filterForJline(final Artifact artifact) {
+        final String artifactId = artifact.getArtifactId();
+        final String groupId = artifact.getGroupId();
+
+        if (artifactId.equals(ScalaConsoleMojo.JLINE) &&
+            (groupId.equals(ScalaConsoleMojo.JLINE) ||
+             groupId.equals(ScalaConsoleMojo.JLINE))) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Hard coded fallback values for JLine. This used to be the only way we
+     * resolve JLine, but required manually upkeep to avoid binary
+     * comparability errors.
+     * <p>
+     * You should favor {@link #resolveJLine} only using this for a fallback
+     * default.
+     * <p>
+     * Current mapping is as follows.
+     * <ul>
+     *   <li>Scala 2.12.0-M4 and after, jline:jline:2.14.1:jar</li>
+     *   <li>After Scala 2.11.0 through Scala 2.12.0-M3, jline:jline:2.12:jar</li>
+     *   <li>After Scala 2.9.0 before Scala 2.11.0, org.scala-lang:jline:SCALA-VERSION:jar</li>
+     *   <li>Before Scala 2.9.0, jline:jline:0.9.94:jar</li>
+     * </ul>
+     *
+     * @param scalaVersion the version of the Scala Compiler/Library we are
+     *        using for this execution.
+     *
+     * @return a fallback {@link Artifact} which we <em>hope</em> will work with
+     *         the Scala REPL.
+     */
+    private Artifact fallbackJLine(final VersionNumber scalaVersion) {
+        // https://github.com/scala/scala/blob/365ac035a863a666f86151371db77c6d401e88a2/versions.properties#L29
+        final VersionNumber scala2_12_0M4 = new VersionNumber("2.12.0-M4");
+        final VersionNumber scala2_11_0 = new VersionNumber("2.11.0");
+        final VersionNumber scala2_9_0 = new VersionNumber("2.9.0");
+
+        if (scala2_12_0M4.compareTo(scalaVersion) <= 0) {
+            return super.factory.createArtifact(ScalaConsoleMojo.JLINE, ScalaConsoleMojo.JLINE, "2.14.1", "", ScalaMojoSupport.JAR);
+        } else if (scala2_11_0.compareTo(scalaVersion) <= 0) {
+            return super.factory.createArtifact(ScalaConsoleMojo.JLINE, ScalaConsoleMojo.JLINE, "2.12", "", ScalaMojoSupport.JAR);
+        } else if (scala2_9_0.compareTo(scalaVersion) <= 0) {
+            return super.factory.createArtifact(ScalaConsoleMojo.SCALA_ORG_GROUP, ScalaConsoleMojo.JLINE, scalaVersion.toString(), "", ScalaMojoSupport.JAR);
+        } else {
+            return super.factory.createArtifact(ScalaConsoleMojo.JLINE, ScalaConsoleMojo.JLINE, "0.9.94", "", ScalaMojoSupport.JAR);
+        }
     }
 }


### PR DESCRIPTION
Derive the JLine dependency from the Scala compiler. This fixes #196 and allows use of `scala:console` with scala 2.12.

**Important**, this PR requires the changes introduced in #205. That PR should be reviewed first. If there are changes made as a result of the review of #205, I'll port them into this PR if/when that PR is merged.

Closes #196 

* `src/main/java/scala_maven/ScalaMojoSupport.java`
  * Added `static` values for a couple `String` values used internally in the
    class, namely "pom" and "jar". Updated usage instances of strings in the
    class to use the constants.
  * Added method to resolve the `Artifact` for the `scala-compiler`.
  * Added more general overloads for `resolveDependencyArtifacts` allowing for
    specification of various artifact filters. Changed the resolution method to
    use the non-deprecated `ArtifactResolutionRequest` type. This is the only
    non-deprecated way to resolve `Artifacts` in Maven as of now.
  * Added an overloaded variant of the `getScalaCommand` which allows
    specification the following behaviors.
    * `forkOverride` - Whether or not to `fork` regardless of the setting in the
      plugin. This currently is only used (and is in fact required) by the
      `scala:console` goal.
    * `mainClass` The JVM class to invoke as main. This currently only has
      use (and is in fact required) by the `scala:console` goal.
  * Added overloaded variant of `getEmptyScalaCommand` that also allows the same
    `forkOverride` behavior seen in `getScalaCommand`. As the former method
    delegates to this one.
  * Updated call to `resolveDependencyArtifacts` to use the
    `resolveArtifactDependencies` operating on the `Artifact` rather than the
    `MavenProject`.
* `src/main/java/scala_maven/ScalaConsoleMojo.java`
  * Added `static` values for a couple `String` values used internally in the
    class, namely "jline" and "org.scala-lang".
  * Updated the `doExecute` method to use the `JavaMainCaller`.
  * Added several `private` methods to choose the correct `jline` dependency
    based on the `scala-compiler` artifact version and dependencies as well as a
    few that just perform general cleanup.
    * `handleJavaRebel` - This method adds the Java Rebel setup if it
      `javaRebelPath` is non-null and the target path exists. The logic this
      method performs is unchanged it was merely factored out into an isolated
      `private` method to reduce noise in the `doExecute` method.
    * `setupClassPathForConsole` - This is the top level `private` method for
      constructing the correct classpath for use with the scala console. It
      merely takes the project classpath and merges it with required console
      classpath.
    * `setupProjectClasspaths` - This method adds the scal compiler and standard
      library to the classpath. It also conditionally adds test classpath and
      runtime classpath.
    * `setupConsoleClasspaths` - Adds any console specific artifacts to the
      classpath. Currently this is just JLine.
    * `resolveJLine` - This method attempts to derive the correct
      JLine dependency to use by finding the version used as an optional
      dependency by the `scala-compiler` artifact at the given version, falling
      back to the hard coded constants that were in use prior to this commit if
      it is unable to resolve the Jline version. Note, I have not found any case
      where it does _fail_ and fallback, but I've left it in here just _in
      case_.
    * `filterForJline` - Filter predicate that is applied to the dependencies on
      the `scala-compiler` to find the JLine dependency.
    * `fallbackJLine` - Fallback constant hard coded values for JLine which are
      only used if we can not derive the correct version from the
      `scala-compiler` artifact.