### PR TITLE
Minor change to use the latest stable jline version

### DIFF
--- a/src/main/java/scala_maven/ScalaConsoleMojo.java
+++ b/src/main/java/scala_maven/ScalaConsoleMojo.java
@@ -61,7 +61,7 @@ public class ScalaConsoleMojo extends ScalaMojoSupport {
         addCompilerToClasspath(classpath);
         addLibraryToClasspath(classpath);
         if (new VersionNumber("2.11.0").compareTo(scalaVersion) <= 0) {
-            addToClasspath("jline", "jline", "2.12", classpath);
+            addToClasspath("jline", "jline", "2.14.3", classpath);
         } else if (new VersionNumber("2.9.0").compareTo(scalaVersion) <= 0) {
           addToClasspath("org.scala-lang", "jline", scalaVersion.toString(), classpath);
         } else {


### PR DESCRIPTION
jline 2.12 doesn't work with scala version >= 2.11.9

however, jline 2.14.3 still doesn't work with scala 2.12