### PR TITLE
Check JAVA_HOME before java.home to locate JDK home

### DIFF
--- a/src/main/java/util/JavaLocator.java
+++ b/src/main/java/util/JavaLocator.java
@@ -19,9 +19,9 @@ public class JavaLocator {
     }
 
     if (toolchain == null || _javaExec == null) {
-      _javaExec = System.getProperty("java.home");
+      _javaExec = System.getenv("JAVA_HOME");
       if (_javaExec == null) {
-        _javaExec = System.getenv("JAVA_HOME");
+        _javaExec = System.getProperty("java.home"); // Points to JRE home
         if (_javaExec == null) {
           throw new IllegalStateException("Couldn't locate java, try setting JAVA_HOME environment variable.");
         }

--- a/src/test/java/util/JavaLocatorTest.java
+++ b/src/test/java/util/JavaLocatorTest.java
@@ -15,7 +15,7 @@ public class JavaLocatorTest {
     @Test
     public void shouldReturnNullWhenJavaIsNotAvailableOnCommandLineAndJavaHomeIsPresent() {
         Toolchain toolchain = new NullReturningToolChain();
-        System.setProperty("java.home", "test");
+        environmentVariables.set("JAVA_HOME", "test");
         assertEquals("test/bin/java", JavaLocator.findExecutableFromToolchain(toolchain));
     }
 
@@ -45,7 +45,7 @@ public class JavaLocatorTest {
     }
 
     @Test
-    public void shouldReturnWhenFileIsNotPresent() throws Exception {
+    public void shouldReturnNullWhenFileIsNotPresent() throws Exception {
         String home = JavaLocator.findHomeFromToolchain(new ReturningToolChain());
         assertNull(home);
     }


### PR DESCRIPTION
`System.getProperty("java.home")` return the path to the JDK and cannot be override. 
`JAVA_HOME` should be checked before this to allow users to actually affect the path sent to the zinc server, other than using the toolchain plugin.

This fixes issue #221.