### PR TITLE
Bump zinc version to 0.3.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
     <dependency>
       <groupId>com.typesafe.zinc</groupId>
       <artifactId>zinc</artifactId>
-      <version>0.3.9</version>
+      <version>0.3.15</version>
     </dependency>
 <!--
     <dependency>


### PR DESCRIPTION
The latest version of zinc is now 0.3.15 and is fully compatible with the previous one.