### PR TITLE
Migrated javadoc-style annotation to Maven Plugin Annotations.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.5</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven.reporting</groupId>
       <artifactId>maven-reporting-api</artifactId>
       <version>${maven.reporting.version}</version>

--- a/src/main/java/scala_maven/AddSourceMojo.java
+++ b/src/main/java/scala_maven/AddSourceMojo.java
@@ -4,67 +4,62 @@ import java.io.File;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
 /**
  * Add more source directories to the POM.
- *
- * @executionStrategy always
- * @goal add-source
- * @phase initialize
- * @requiresDirectInvocation false
- * @threadSafe
  */
+@Mojo(name = "add-source", executionStrategy = "always", defaultPhase = LifecyclePhase.INITIALIZE, requiresDirectInvocation = false, threadSafe = true)
 public class AddSourceMojo extends AbstractMojo {
 
     /**
      * The maven project
-     *
-     * @parameter property="project"
-     * @required
-     * @readonly
      */
+    @Parameter(property = "project", required = true, readonly = true)
     private MavenProject project;
 
     /**
      * The directory in which scala source is found
-     *
-     * @parameter default-value="${project.build.sourceDirectory}/../scala"
      */
+    @Parameter(defaultValue = "${project.build.sourceDirectory}/../scala")
     protected File sourceDir;
 
     /**
      * The directory in which testing scala source is found
-     *
-     * @parameter default-value="${project.build.testSourceDirectory}/../scala"
      */
+    @Parameter(defaultValue = "${project.build.testSourceDirectory}/../scala")
     protected File testSourceDir;
 
     /**
-     * Should use CanonicalPath to normalize path (true => getCanonicalPath, false => getAbsolutePath)
+     * Should use CanonicalPath to normalize path (true => getCanonicalPath, false
+     * => getAbsolutePath)
+     * 
      * @see https://github.com/davidB/maven-scala-plugin/issues/50
-     * @parameter property="maven.scala.useCanonicalPath" default-value="true"
      */
+    @Parameter(property = "maven.scala.useCanonicalPath", defaultValue = "true")
     protected boolean useCanonicalPath = true;
-    
+
     @Override
     public void execute() throws MojoExecutionException {
         try {
             if (sourceDir != null) {
-                String path = FileUtils.pathOf(sourceDir, useCanonicalPath);
+                final String path = FileUtils.pathOf(sourceDir, useCanonicalPath);
                 if (!project.getCompileSourceRoots().contains(path)) {
                     getLog().info("Add Source directory: " + path);
                     project.addCompileSourceRoot(path);
                 }
             }
             if (testSourceDir != null) {
-                String path = FileUtils.pathOf(testSourceDir, useCanonicalPath);
+                final String path = FileUtils.pathOf(testSourceDir, useCanonicalPath);
                 if (!project.getTestCompileSourceRoots().contains(path)) {
                     getLog().info("Add Test Source directory: " + path);
                     project.addTestCompileSourceRoot(path);
                 }
             }
-        } catch(Exception exc) {
+        } catch (final Exception exc) {
             getLog().warn(exc);
         }
     }

--- a/src/main/java/scala_maven/Launcher.java
+++ b/src/main/java/scala_maven/Launcher.java
@@ -1,5 +1,7 @@
 package scala_maven;
 
+import org.apache.maven.plugins.annotations.Parameter;
+
 public class Launcher {
     protected String id;
 
@@ -7,15 +9,13 @@ public class Launcher {
 
     /**
      * Jvm Arguments
-     *
-     * @parameter
      */
+    @Parameter
     protected String[] jvmArgs;
 
     /**
      * compiler additionnals arguments
-     *
-     * @parameter
      */
+    @Parameter
     protected String[] args;
 }

--- a/src/main/java/scala_maven/ScalaCompileMojo.java
+++ b/src/main/java/scala_maven/ScalaCompileMojo.java
@@ -1,41 +1,40 @@
- package scala_maven;
+package scala_maven;
 
 import java.io.File;
 import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.maven.model.Dependency;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
  * Compiles a directory of Scala source. Corresponds roughly to the compile goal
  * of the maven-compiler-plugin
  *
- * @phase compile
- * @goal compile
- * @requiresDependencyResolution compile
- * @threadSafe
  */
+@Mojo(name = "compile", defaultPhase = LifecyclePhase.COMPILE, requiresDependencyResolution = ResolutionScope.COMPILE, threadSafe = true)
 public class ScalaCompileMojo extends ScalaCompilerSupport {
 
     /**
      * The directory in which to place compilation output
-     *
-     * @parameter property="project.build.outputDirectory"
      */
+    @Parameter(property = "project.build.outputDirectory")
     protected File outputDir;
 
     /**
      * The directory which contains scala/java source files
-     *
-     * @parameter default-value="${project.build.sourceDirectory}/../scala"
      */
+    @Parameter(defaultValue = "${project.build.sourceDirectory}/../scala")
     protected File sourceDir;
 
     /**
      * Analysis cache file for incremental recompilation.
      *
-     * @parameter property="analysisCacheFile" default-value="${project.build.directory}/analysis/compile"
      */
+    @Parameter(property = "analysisCacheFile", defaultValue = "${project.build.directory}/analysis/compile")
     protected File analysisCacheFile;
 
     @Override

--- a/src/main/java/scala_maven/ScalaCompilerSupport.java
+++ b/src/main/java/scala_maven/ScalaCompilerSupport.java
@@ -1,16 +1,23 @@
 package scala_maven;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
+
 import sbt_inc.SbtIncrementalCompiler;
 import scala_maven_executions.JavaMainCaller;
 import scala_maven_executions.MainHelper;
-
-import java.io.File;
-import java.util.*;
 
 /**
  * Abstract parent of all Scala Mojo who run compilation
@@ -27,21 +34,25 @@ public abstract class ScalaCompilerSupport extends ScalaSourceMojoSupport {
     private boolean compileErrors;
 
     /**
-     * Recompile mode to use when sources were previously compiled and there is at least one change:
-     * "modified-only" => only modified sources are recompiled (pre 2.13 behavior), "all" => all sources are recompiled,
-     * "incremental" => incrementally recompile modified sources and other affected sources.
+     * Recompile mode to use when sources were previously compiled and there is at
+     * least one change:
+     * "modified-only" => only modified sources are recompiled (pre 2.13 behavior),
+     * "all" => all sources are recompiled,
+     * "incremental" => incrementally recompile modified sources and other affected
+     * sources.
      *
-     * @parameter property="recompileMode" default-value="all"
      */
+    @Parameter(property = "recompileMode", defaultValue = "all")
     protected String recompileMode = ALL;
 
     /**
      * notifyCompilation if true then print a message "path: compiling"
      * for each root directory or files that will be compiled.
-     * Useful for debug, and for integration with Editor/IDE to reset markers only for compiled files.
+     * Useful for debug, and for integration with Editor/IDE to reset markers only
+     * for compiled files.
      *
-     * @parameter property="notifyCompilation" default-value="true"
      */
+    @Parameter(property = "notifyCompilation", defaultValue = "true")
     private boolean notifyCompilation = true;
 
     abstract protected File getOutputDir() throws Exception;
@@ -62,29 +73,29 @@ public abstract class ScalaCompilerSupport extends ScalaSourceMojoSupport {
      *
      * Can be Mixed, JavaThenScala, or ScalaThenJava.
      *
-     * @parameter property="compileOrder" default-value="mixed"
      */
+    @Parameter(property = "compileOrder", defaultValue = "mixed")
     private String compileOrder;
 
     /**
      * Use zinc server for incremental recompilation.
-     *
-     * @parameter property="useZincServer" default-value="false"
      */
+    @Parameter(property = "useZincServer", defaultValue = "false")
     private boolean useZincServer;
 
     /**
      * Zinc server port, if running with incremental zinc server mode.
-     *
-     * @parameter property="zincPort" default-value="3030"
      */
+    @Parameter(property = "zincPort", defaultValue = "3030")
     private int zincPort;
 
     /**
      * Additional parameter to use to call zinc server
-     * It is a pipe '|' separated list of arguments, so it can be used from command line ("-DaddZincArgs=arg1|arg2|arg3|...").
-     * @parameter property="addZincArgs"
+     * It is a pipe '|' separated list of arguments, so it can be used from command
+     * line ("-DaddZincArgs=arg1|arg2|arg3|...").
+     * 
      */
+    @Parameter(property = "addZincArgs")
     private String addZincArgs = "";
 
     @Override

--- a/src/main/java/scala_maven/ScalaConsoleMojo.java
+++ b/src/main/java/scala_maven/ScalaConsoleMojo.java
@@ -2,27 +2,23 @@ package scala_maven;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
 
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
 import scala_maven_executions.JavaMainCaller;
-import scala_maven_executions.JavaMainCallerInProcess;
 import scala_maven_executions.MainHelper;
 
-import org.apache.maven.artifact.Artifact;
-
 /**
- * Run the Scala console with all the classes of the projects (dependencies and builded)
+ * Run the Scala console with all the classes of the projects (dependencies and
+ * builded)
  *
- * @goal console
- * @requiresDependencyResolution test
- * @inheritByDefault false
- * @requiresDirectInvocation true
- * @executionStrategy once-per-session
  */
+@Mojo(name = "console", requiresDependencyResolution = ResolutionScope.TEST, inheritByDefault = false, requiresDirectInvocation = true, executionStrategy = "once-per-session")
 public class ScalaConsoleMojo extends ScalaMojoSupport {
 
     // Private Static Values //
@@ -44,33 +40,32 @@ public class ScalaConsoleMojo extends ScalaMojoSupport {
     /**
      * The console to run.
      *
-     * @parameter property="mainConsole" default-value="scala.tools.nsc.MainGenericRunner"
-     * @required
      */
+    @Parameter(property = "mainConsole", defaultValue = "scala.tools.nsc.MainGenericRunner", required = true)
     protected String mainConsole;
 
     /**
-     * Add the test classpath (include classes from test directory), to the console's classpath ?
+     * Add the test classpath (include classes from test directory), to the
+     * console's classpath ?
      *
-     * @parameter property="maven.scala.console.useTestClasspath" default-value="true"
-     * @required
      */
+    @Parameter(property = "maven.scala.console.useTestClasspath", defaultValue = "true", required = true)
     protected boolean useTestClasspath;
 
     /**
      * Add the runtime classpath, to the console's classpath ?
      *
-     * @parameter property="maven.scala.console.useRuntimeClasspath" default-value="true"
-     * @required
      */
+    @Parameter(property = "maven.scala.console.useRuntimeClasspath", defaultValue = "true", required = true)
     protected boolean useRuntimeClasspath;
 
     /**
      * Path of the javaRebel jar. If this option is set then the console run
-     * with <a href="http://www.zeroturnaround.com/javarebel/">javarebel</a> enabled.
+     * with <a href="http://www.zeroturnaround.com/javarebel/">javarebel</a>
+     * enabled.
      *
-     * @parameter property="javarebel.jar.path"
      */
+    @Parameter(property = "javarebel.jar.path")
     protected File javaRebelPath;
 
     @Override
@@ -87,7 +82,6 @@ public class ScalaConsoleMojo extends ScalaMojoSupport {
         }
 
         // Setup the classpath
-
 
         // Build the classpath string.
         final String classpathStr = MainHelper.toMultiPath(classpath.toArray(new String[classpath.size()]));

--- a/src/main/java/scala_maven/ScalaContinuousCompileMojo.java
+++ b/src/main/java/scala_maven/ScalaContinuousCompileMojo.java
@@ -4,77 +4,84 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
 import scala_maven_executions.JavaMainCaller;
 
 /**
- * Compile the main and test scala source directory in continuous (infinite loop). !! This is an util goal for commandline usage only (Do not use or call it in a pom) !!!
+ * Compile the main and test scala source directory in continuous (infinite
+ * loop). !! This is an util goal for commandline usage only (Do not use or call
+ * it in a pom) !!!
  *
- * @goal cc
- * @requiresDependencyResolution test
  */
+@Mojo(name = "cc", requiresDependencyResolution = ResolutionScope.TEST)
 public class ScalaContinuousCompileMojo extends ScalaCompilerSupport {
 
     /**
      * The output directory for compilation.
      *
-     * @parameter property="project.build.outputDirectory"
      */
+    @Parameter(property="project.build.outputDirectory")
     protected File mainOutputDir;
 
     /**
      * The main directory containing scala source for compilation
      *
-     * @parameter default-value="${project.build.sourceDirectory}/../scala"
      */
+     @Parameter (defaultValue="${project.build.sourceDirectory}/../scala")
     protected File mainSourceDir;
 
     /**
      * The directory to place test compilation output in
      *
-     * @parameter default-value="${project.build.testOutputDirectory}
      */
+     @Parameter(defaultValue="${project.build.testOutputDirectory}")
     protected File testOutputDir;
 
     /**
      * The directory containing test source for compilation
      *
-     * @parameter default-value="${project.build.testSourceDirectory}/../scala"
      */
+     @Parameter (defaultValue="${project.build.testSourceDirectory}/../scala")
     protected File testSourceDir;
 
     /**
      * Analysis cache file for incremental recompilation.
      *
-     * @parameter property="analysisCacheFile" default-value="${project.build.directory}/analysis/compile"
      */
+     @Parameter (property="analysisCacheFile", defaultValue="${project.build.directory}/analysis/compile")
     protected File analysisCacheFile;
 
     /**
      * Analysis cache file for incremental recompilation.
      *
-     * @parameter property="testAnalysisCacheFile" default-value="${project.build.directory}/analysis/test-compile"
      */
+     @Parameter (property="testAnalysisCacheFile", defaultValue="${project.build.directory}/analysis/test-compile")
     protected File testAnalysisCacheFile;
 
     /**
      * Define if fsc should be used, else scalac is used.
      * fsc => scala.tools.nsc.CompileClient, scalac => scala.tools.nsc.Main.
      *
-     * @parameter property="fsc" default-value="true"
      */
+     @Parameter(property="fsc", defaultValue="true")
     protected boolean useFsc = true;
 
     /**
-     * Define if cc should run once or in infinite loop. (useful for test or working with editor)
-     * @parameter property="once" default-value="false"
+     * Define if cc should run once or in infinite loop. (useful for test or working
+     * with editor)
+     * 
      */
+     @Parameter(property="once", defaultValue="false")
     protected boolean once = false;
 
     /**
      * Turns verbose output on.
      *
-     * @parameter property="verbose" default-value="false"
      */
+     @Parameter(property="verbose", defaultValue="false")
     protected boolean verbose = false;
 
     @Override

--- a/src/main/java/scala_maven/ScalaContinuousTestMojo.java
+++ b/src/main/java/scala_maven/ScalaContinuousTestMojo.java
@@ -6,6 +6,10 @@ import java.util.List;
 import java.util.Properties;
 
 import org.apache.maven.BuildFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.shared.invoker.CommandLineConfigurationException;
 import org.apache.maven.shared.invoker.DefaultInvocationRequest;
 import org.apache.maven.shared.invoker.InvocationRequest;
@@ -16,45 +20,48 @@ import org.apache.maven.shared.invoker.SystemOutHandler;
 import org.codehaus.plexus.util.StringUtils;
 
 /**
- * Compile the main and test scala source directory then run unit test cases in continuous (infinite loop).
- * This is an util goal for commandline usage only (Do not use or call it in a pom) !!!
+ * Compile the main and test scala source directory then run unit test cases in
+ * continuous (infinite loop).
+ * This is an util goal for commandline usage only (Do not use or call it in a
+ * pom) !!!
  *
- * @version $Revision: 1.1 $
- * @goal cctest
- * @requiresDependencyResolution test
  */
-
+@Mojo(name = "cctest", requiresDependencyResolution = ResolutionScope.TEST)
 public class ScalaContinuousTestMojo extends ScalaContinuousCompileMojo {
 
-    /**
-     * @component
-     */
+    @Component
     protected Invoker invoker;
 
-
     /**
-     * The local repository for caching artifacts. It is strongly recommended to specify a path to an isolated
-     * repository like <code>${project.build.directory}/it-repo</code>. Otherwise, your ordinary local repository will
+     * The local repository for caching artifacts. It is strongly recommended to
+     * specify a path to an isolated
+     * repository like <code>${project.build.directory}/it-repo</code>. Otherwise,
+     * your ordinary local repository will
      * be used, potentially soiling it with broken artifacts.
      *
-     * @parameter property="${invoker.localRepositoryPath}" default-value="${settings.localRepository}"
      */
+    @Parameter(property = "invoker.localRepositoryPath", defaultValue = "${settings.localRepository}")
     protected File localRepositoryPath;
 
     /**
-     * Specify this parameter to run individual tests by file name, overriding the <code>includes/excludes</code>
-     * parameters.  Each pattern you specify here will be used to create an
-     * include pattern formatted like <code>**&#47;${test}.java</code>, so you can just type "-Dtest=MyTest"
-     * to run a single test called "foo/MyTest.java".  This parameter will override the TestNG suiteXmlFiles
+     * Specify this parameter to run individual tests by file name, overriding the
+     * <code>includes/excludes</code>
+     * parameters. Each pattern you specify here will be used to create an
+     * include pattern formatted like <code>**&#47;${test}.java</code>, so you can
+     * just type "-Dtest=MyTest"
+     * to run a single test called "foo/MyTest.java". This parameter will override
+     * the TestNG suiteXmlFiles
      * parameter.
      *
-     * @parameter property="test"
      */
+    @Parameter(property = "test")
     protected String test;
 
     /**
-     * A space-separated list of the goals to execute as part of running the tests. You can use this
-     * setting to run different testing tools other than just JUnit. For example, to run the
+     * A space-separated list of the goals to execute as part of running the tests.
+     * You can use this
+     * setting to run different testing tools other than just JUnit. For example, to
+     * run the
      * ScalaTest (with the maven-scalatest-plugin):
      *
      * <pre>
@@ -67,7 +74,8 @@ public class ScalaContinuousTestMojo extends ScalaContinuousCompileMojo {
      *   mvn -Dcctest.goals="surefire:test scalatest:test" scala:cctest
      * </pre>
      *
-     * If you need to specify the goal every time you run <code>scala:cctest</code>, you can
+     * If you need to specify the goal every time you run <code>scala:cctest</code>,
+     * you can
      * configure the setting in the pom.xml:
      *
      * <pre>
@@ -82,8 +90,8 @@ public class ScalaContinuousTestMojo extends ScalaContinuousCompileMojo {
      *    &lt;/plugin&gt;
      * </pre>
      *
-     * @parameter property="cctest.goals" default-value="surefire:test"
      */
+    @Parameter(property = "cctest.goals", defaultValue = "surefire:test")
     protected String ccTestGoals;
 
     @Override

--- a/src/main/java/scala_maven/ScalaDocJarMojo.java
+++ b/src/main/java/scala_maven/ScalaDocJarMojo.java
@@ -10,8 +10,13 @@ import org.apache.maven.archiver.MavenArchiver;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProjectHelper;
 import org.apache.maven.reporting.MavenReportException;
+import org.codehaus.plexus.archiver.Archiver;
 import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.jar.JarArchiver;
 import org.codehaus.plexus.archiver.jar.ManifestException;
@@ -19,181 +24,189 @@ import org.codehaus.plexus.archiver.jar.ManifestException;
 /**
  * Creates a jar of the non-aggregated scaladoc and attaches it
  * to the project for distribution.
- * @goal doc-jar
- * @phase package
  *
  */
+@Mojo(name = "doc-jar", defaultPhase = LifecyclePhase.PACKAGE)
 public class ScalaDocJarMojo extends ScalaDocMojo {
 
-  private static final String[] DEFAULT_INCLUDES = new String[] { "**/**" };
-  private static final String[] DEFAULT_EXCLUDES = new String[] {};
-  /**
-   * The Jar archiver.
-   *
-   * @component role="org.codehaus.plexus.archiver.Archiver" roleHint="jar"
-   */
-  private JarArchiver jarArchiver;
+    private static final String[] DEFAULT_INCLUDES = new String[] { "**/**" };
+    private static final String[] DEFAULT_EXCLUDES = new String[] {};
+    /**
+     * The Jar archiver.
+     *
+     */
+    @Component(role = Archiver.class, hint = "jar")
+    private JarArchiver jarArchiver;
 
-  /**
-  * Used for attaching the artifact in the project.
-  *
-  * @component
-  */
-  private MavenProjectHelper projectHelper;
-  /**
-   * Specifies the filename that will be used for the generated jar file. Please note that <code>-javadoc</code>
-   * or <code>-test-javadoc</code> will be appended to the file name.
-   *
-   * @parameter property="project.build.finalName"
-   */
-  private String finalName;
-  /**
-   * Specifies whether to attach the generated artifact to the project helper.
-   * <br/>
-   *
-   * @parameter property="attach" default-value="true"
-   */
-  private boolean attach;
-  /**
-   * Specifies the classifier of the generated artifact.
-   *
-   * @parameter property="classifier" default-value="javadoc"
-   */
-  private String classifier;
-  /**
-   * Specifies whether to skip generating scaladoc.
-   *
-   * @parameter property="skip" default-value="false"
-   */
-  private boolean skip;
-  /**
-   * Specifies the directory where the generated jar file will be put.
-   *
-   * @parameter property="project.build.directory"
-   */
-  private String jarOutputDirectory;
-  /**
-   * The archive configuration to use.
-   * See <a href="http://maven.apache.org/shared/maven-archiver/index.html">Maven Archiver Reference</a>.
-   *
-   * @parameter
-   */
-  private MavenArchiveConfiguration archive = new MavenArchiveConfiguration();
+    /**
+     * Used for attaching the artifact in the project.
+     *
+     */
+    @Component
+    private MavenProjectHelper projectHelper;
 
-  /**
-   * Path to the default MANIFEST file to use. It will be used if
-   * <code>useDefaultManifestFile</code> is set to <code>true</code>.
-   *
-   * @parameter default-value="${project.build.outputDirectory}/META-INF/MANIFEST.MF"
-   * @required
-   * @readonly
-   */
-  private File defaultManifestFile;
+    /**
+     * Specifies the filename that will be used for the generated jar file. Please
+     * note that <code>-javadoc</code>
+     * or <code>-test-javadoc</code> will be appended to the file name.
+     *
+     */
+    @Parameter(property = "project.build.finalName")
+    private String finalName;
 
-  /**
-   * Set this to <code>true</code> to enable the use of the <code>defaultManifestFile</code>.
-   * <br/>
-   *
-   * @parameter default-value="false"
-   */
-  private boolean useDefaultManifestFile;
+    /**
+     * Specifies whether to attach the generated artifact to the project helper.
+     * <br/>
+     *
+     */
+    @Parameter(property = "attach", defaultValue = "true")
+    private boolean attach;
 
-  /**
-   * Specifies if the build will fail if there are errors during javadoc execution or not.
-   *
-   * @parameter property="maven.javadoc.failOnError" default-value="true"
-   * @since 2.5
-   */
-  protected boolean failOnError;
+    /**
+     * Specifies the classifier of the generated artifact.
+     *
+     */
+    @Parameter(property = "classifier", defaultValue = "javadoc")
+    private String classifier;
 
-  @Override
-  public void doExecute() throws Exception {
-    if(skip) {
-      getLog().info( "Skipping javadoc generation" );
-      return;
-    }
-    try {
-      generate(null, Locale.getDefault());
-      if(reportOutputDirectory.exists()) {
-        File outputFile = generateArchive( reportOutputDirectory, finalName + "-" + getClassifier() + ".jar" );
-        if(!attach ) {
-          getLog().info( "NOT adding javadoc to attached artifacts list." );
-        } else {
-          // TODO: these introduced dependencies on the project are going to become problematic - can we export it
-          //  through metadata instead?
-          projectHelper.attachArtifact( project, "javadoc", getClassifier(), outputFile );
+    /**
+     * Specifies whether to skip generating scaladoc.
+     *
+     */
+    @Parameter(property = "skip", defaultValue = "false")
+    private boolean skip;
+
+    /**
+     * Specifies the directory where the generated jar file will be put.
+     *
+     */
+    @Parameter(property = "project.build.directory")
+    private String jarOutputDirectory;
+
+    /**
+     * The archive configuration to use.
+     * See <a href="http://maven.apache.org/shared/maven-archiver/index.html">Maven
+     * Archiver Reference</a>.
+     *
+     */
+    @Parameter
+    private MavenArchiveConfiguration archive = new MavenArchiveConfiguration();
+
+    /**
+     * Path to the default MANIFEST file to use. It will be used if
+     * <code>useDefaultManifestFile</code> is set to <code>true</code>.
+     *
+     */
+    @Parameter(defaultValue = "${project.build.outputDirectory}/META-INF/MANIFEST.MF", required = true, readonly = true)
+    private File defaultManifestFile;
+
+    /**
+     * Set this to <code>true</code> to enable the use of the
+     * <code>defaultManifestFile</code>.
+     * <br/>
+     *
+     */
+    @Parameter(defaultValue = "false")
+    private boolean useDefaultManifestFile;
+
+    /**
+     * Specifies if the build will fail if there are errors during javadoc execution
+     * or not.
+     *
+     * @since 2.5
+     */
+    @Parameter(property="maven.javadoc.failOnError", defaultValue="true")
+    protected boolean failOnError;
+
+    @Override
+    public void doExecute() throws Exception {
+        if (skip) {
+            getLog().info("Skipping javadoc generation");
+            return;
         }
-      }
-    } catch (ArchiverException e) {
-      failOnError( "ArchiverException: Error while creating archive", e );
-    } catch (IOException e) {
-      failOnError( "IOException: Error while creating archive", e );
-    } catch ( MavenReportException e ) {
-      failOnError( "MavenReportException: Error while creating archive", e );
-    } catch ( RuntimeException e ) {
-      failOnError( "RuntimeException: Error while creating archive", e );
+        try {
+            generate(null, Locale.getDefault());
+            if (reportOutputDirectory.exists()) {
+                final File outputFile = generateArchive(reportOutputDirectory, finalName + "-" + getClassifier() + ".jar");
+                if (!attach) {
+                    getLog().info("NOT adding javadoc to attached artifacts list.");
+                } else {
+                    // TODO: these introduced dependencies on the project are going to become
+                    // problematic - can we export it
+                    // through metadata instead?
+                    projectHelper.attachArtifact(project, "javadoc", getClassifier(), outputFile);
+                }
+            }
+        } catch (final ArchiverException e) {
+            failOnError("ArchiverException: Error while creating archive", e);
+        } catch (final IOException e) {
+            failOnError("IOException: Error while creating archive", e);
+        } catch (final MavenReportException e) {
+            failOnError("MavenReportException: Error while creating archive", e);
+        } catch (final RuntimeException e) {
+            failOnError("RuntimeException: Error while creating archive", e);
+        }
     }
-  }
 
+    /**
+     * Method that creates the jar file
+     *
+     * @param javadocFiles
+     *            the directory where the generated jar file will be put
+     * @param jarFileName
+     *            the filename of the generated jar file
+     * @return a File object that contains the generated jar file
+     * @throws ArchiverException
+     * @throws IOException
+     */
+    private File generateArchive(File javadocFiles, String jarFileName) throws ArchiverException, IOException {
+        final File javadocJar = new File(jarOutputDirectory, jarFileName);
+        if (javadocJar.exists()) {
+            javadocJar.delete();
+        }
+        final MavenArchiver archiver = new MavenArchiver();
+        archiver.setArchiver(jarArchiver);
+        archiver.setOutputFile(javadocJar);
+        final File contentDirectory = javadocFiles;
+        if (!contentDirectory.exists()) {
+            getLog().warn("JAR will be empty - no content was marked for inclusion!");
+        } else {
+            archiver.getArchiver().addDirectory(contentDirectory, DEFAULT_INCLUDES, DEFAULT_EXCLUDES);
+        }
+        final List<Resource> resources = project.getBuild().getResources();
+        for (final Resource r : resources) {
+            if (r.getDirectory().endsWith("maven-shared-archive-resources")) {
+                archiver.getArchiver().addDirectory(new File(r.getDirectory()));
+            }
+        }
+        if (useDefaultManifestFile && defaultManifestFile.exists() && archive.getManifestFile() == null) {
+            getLog().info("Adding existing MANIFEST to archive. Found under: " + defaultManifestFile.getPath());
+            archive.setManifestFile(defaultManifestFile);
+        }
+        try {
+            // we don't want Maven stuff
+            archive.setAddMavenDescriptor(false);
+            archiver.createArchive(session, project, archive);
+        } catch (final ManifestException e) {
+            throw new ArchiverException("ManifestException: " + e.getMessage(), e);
+        } catch (final DependencyResolutionRequiredException e) {
+            throw new ArchiverException("DependencyResolutionRequiredException: " + e.getMessage(), e);
+        }
+        return javadocJar;
+    }
 
+    protected String getClassifier() {
+        return classifier;
+    }
 
-  /**
-   * Method that creates the jar file
-   *
-   * @param javadocFiles the directory where the generated jar file will be put
-   * @param jarFileName the filename of the generated jar file
-   * @return a File object that contains the generated jar file
-   * @throws ArchiverException
-   * @throws IOException
-   */
-  private File generateArchive( File javadocFiles, String jarFileName ) throws ArchiverException, IOException {
-    final File javadocJar = new File( jarOutputDirectory, jarFileName );
-    if(javadocJar.exists()) {
-      javadocJar.delete();
+    protected void failOnError(String prefix, Exception e)
+            throws MojoExecutionException {
+        if (failOnError) {
+            if (e instanceof RuntimeException) {
+                throw (RuntimeException) e;
+            }
+            throw new MojoExecutionException(prefix + ": " + e.getMessage(), e);
+        }
+        getLog().error(prefix + ": " + e.getMessage(), e);
     }
-    MavenArchiver archiver = new MavenArchiver();
-    archiver.setArchiver( jarArchiver );
-    archiver.setOutputFile( javadocJar );
-    File contentDirectory = javadocFiles;
-    if(!contentDirectory.exists()) {
-      getLog().warn( "JAR will be empty - no content was marked for inclusion!" );
-    } else {
-      archiver.getArchiver().addDirectory( contentDirectory, DEFAULT_INCLUDES, DEFAULT_EXCLUDES );
-    }
-    List<Resource> resources = project.getBuild().getResources();
-    for ( Resource r : resources ) {
-      if ( r.getDirectory().endsWith( "maven-shared-archive-resources" ) ) {
-        archiver.getArchiver().addDirectory( new File( r.getDirectory() ) );
-      }
-    }
-    if ( useDefaultManifestFile && defaultManifestFile.exists() && archive.getManifestFile() == null ) {
-      getLog().info("Adding existing MANIFEST to archive. Found under: " + defaultManifestFile.getPath());
-      archive.setManifestFile(defaultManifestFile);
-    }
-    try {
-      // we don't want Maven stuff
-      archive.setAddMavenDescriptor( false );
-      archiver.createArchive(session, project, archive );
-    } catch ( ManifestException e ) {
-      throw new ArchiverException( "ManifestException: " + e.getMessage(), e );
-    } catch ( DependencyResolutionRequiredException e ) {
-      throw new ArchiverException( "DependencyResolutionRequiredException: " + e.getMessage(), e );
-    }
-    return javadocJar;
-  }
-
-  protected String getClassifier() {
-    return classifier;
-  }
-
-  protected void failOnError(String prefix, Exception e)
-      throws MojoExecutionException {
-    if (failOnError) {
-      if (e instanceof RuntimeException) {
-        throw (RuntimeException) e;
-      }
-      throw new MojoExecutionException(prefix + ": " + e.getMessage(), e);
-    }
-    getLog().error(prefix + ": " + e.getMessage(), e);
-  }
 }

--- a/src/main/java/scala_maven/ScalaDocMojo.java
+++ b/src/main/java/scala_maven/ScalaDocMojo.java
@@ -1,35 +1,39 @@
 package scala_maven;
 
-import org.apache.maven.project.MavenProject;
-import org.apache.maven.reporting.MavenReport;
-import org.apache.maven.reporting.MavenReportException;
-import org.codehaus.doxia.sink.Sink;
-import org.codehaus.plexus.util.StringUtils;
-import scala_maven_executions.JavaMainCaller;
-import scala_maven_executions.MainHelper;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Locale;
 
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.reporting.MavenReport;
+import org.apache.maven.reporting.MavenReportException;
+import org.codehaus.doxia.sink.Sink;
+import org.codehaus.plexus.util.StringUtils;
+
+import scala_maven_executions.JavaMainCaller;
+import scala_maven_executions.MainHelper;
+
 /**
  * Produces Scala API documentation.
  *
- * @goal doc
- * @requiresDependencyResolution compile
- * @execute phase="generate-sources"
  */
+@Mojo(name = "doc", requiresDependencyResolution = ResolutionScope.COMPILE)
+@Execute(phase = LifecyclePhase.GENERATE_RESOURCES)
 public class ScalaDocMojo extends ScalaSourceMojoSupport implements MavenReport {
 
     /**
      * Specify window title of generated HTML documentation.
      * [scaladoc, vscaladoc]
      *
-     * @parameter property="windowtitle"
-     *            default-value="${project.name} ${project.version} API"
      */
+    @Parameter(property = "windowtitle", defaultValue = "${project.name} ${project.version} API")
     protected String windowtitle;
 
     /**
@@ -39,144 +43,143 @@ public class ScalaDocMojo extends ScalaSourceMojoSupport implements MavenReport 
      * href="http://www.mycompany.com">MyCompany, Inc.&lt;a>]]&gt;
      * [scaladoc, vscaladoc]
      *
-     * @parameter property="bottom"
-     *            default-value="Copyright (c) {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved."
      */
+    @Parameter(property = "bottom", defaultValue = "Copyright (c) {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.")
     protected String bottom;
 
     /**
      * Charset for cross-platform viewing of generated documentation.
      * [scaladoc, vscaladoc]
      *
-     * @parameter property="charset" default-value="ISO-8859-1"
      */
+    @Parameter(property = "charset", defaultValue = "ISO-8859-1")
     protected String charset;
 
     /**
      * Include title for the overview page.
      * [scaladoc, scaladoc2, vscaladoc]
      *
-     * @parameter property="doctitle"
-     *            default-value="${project.name} ${project.version} API"
      */
+    @Parameter(property = "doctitle", defaultValue = "${project.name} ${project.version} API")
     protected String doctitle;
 
     /**
      * Include footer text for each page.
      * [scaladoc, vscaladoc]
      *
-     * @parameter property="footer"
      */
+    @Parameter(property = "footer")
     protected String footer;
 
     /**
      * Include header text for each page
      * [scaladoc, vscaladoc]
      *
-     * @parameter property="header"
      */
+    @Parameter(property = "header")
     protected String header;
 
     /**
      * Generate source in HTML
      * [scaladoc, vscaladoc]
      *
-     * @parameter property="linksource" default-value="true"
      */
+    @Parameter(property = "linksource", defaultValue = "true")
     protected boolean linksource;
 
     /**
      * Suppress description and tags, generate only declarations
      * [scaladoc, vscaladoc]
      *
-     * @parameter property="nocomment" default-value="false"
      */
+    @Parameter(property = "nocomment", defaultValue = "false")
     protected boolean nocomment;
 
     /**
      * File to change style of the generated documentation
      * [scaladoc, vscaladoc]
      *
-     * @parameter property="stylesheetfile"
      */
+    @Parameter(property = "stylesheetfile")
     protected File stylesheetfile;
 
     /**
      * Include top text for each page
      * [scaladoc, vscaladoc]
      *
-     * @parameter property="top"
      */
+    @Parameter(property = "top")
     protected String top;
 
     /**
      * Specifies the destination directory where scalaDoc saves the generated
      * HTML files.
      *
-     * @parameter default-value="scaladocs"
-     * @required
      */
+    @Parameter(defaultValue = "scaladocs", required = true)
     protected String outputDirectory;
 
     /**
-     * Specifies the destination directory where javadoc saves the generated HTML files.
+     * Specifies the destination directory where javadoc saves the generated HTML
+     * files.
      *
-     * @parameter default-value="${project.reporting.outputDirectory}/scaladocs"
-     * @required
      */
+    @Parameter(defaultValue = "${project.reporting.outputDirectory}/scaladocs", required = true)
     protected File reportOutputDirectory;
 
     /**
      * The name of the Scaladoc report.
      *
      * @since 2.1
-     * @parameter property="name" default-value="ScalaDocs"
      */
+    @Parameter(property = "name", defaultValue = "ScalaDocs")
     private String name;
 
     /**
      * The description of the Scaladoc report.
      *
      * @since 2.1
-     * @parameter property="description" default-value="ScalaDoc API
-     *            documentation."
      */
+    @Parameter(property = "description", defaultValue = "ScalaDoc API documentation.")
     private String description;
 
     /**
-     * className (FQN) of the main scaladoc to use, if not define, the the scalaClassName is used
+     * className (FQN) of the main scaladoc to use, if not define, the the
+     * scalaClassName is used
      *
-     * @parameter property="maven.scaladoc.className"
      */
+    @Parameter(property = "maven.scaladoc.className")
     protected String scaladocClassName;
 
     /**
-     * If you want to use vscaladoc to generate api instead of regular scaladoc, set the version of vscaladoc you want to use.
+     * If you want to use vscaladoc to generate api instead of regular scaladoc, set
+     * the version of vscaladoc you want to use.
      *
-     * @parameter property="maven.scaladoc.vscaladocVersion"
      */
+    @Parameter(property = "maven.scaladoc.vscaladocVersion")
     protected String vscaladocVersion;
 
     /**
-     * To allow running aggregation only from command line use "-DforceAggregate=true" (avoid using in pom.xml).
+     * To allow running aggregation only from command line use
+     * "-DforceAggregate=true" (avoid using in pom.xml).
      * [scaladoc, vscaladoc]
      *
-     * @parameter property="forceAggregate" default-value="false"
      */
+    @Parameter(property = "forceAggregate", defaultValue = "false")
     protected boolean forceAggregate = false;
 
     /**
      * If you want to aggregate only direct sub modules.
      *
-     * @parameter property="maven.scaladoc.aggregateDirectOnly" default-value="true"
      */
+    @Parameter(property = "maven.scaladoc.aggregateDirectOnly", defaultValue = "true")
     protected boolean aggregateDirectOnly = true;
 
     /**
      * The directory which contains scala/java source files
      *
-     * @parameter default-value="${project.build.sourceDirectory}/../scala"
      */
+    @Parameter(defaultValue = "${project.build.sourceDirectory}/../scala")
     protected File sourceDir;
 
     private List<File> _sourceFiles;

--- a/src/main/java/scala_maven/ScalaHelpMojo.java
+++ b/src/main/java/scala_maven/ScalaHelpMojo.java
@@ -1,19 +1,22 @@
 package scala_maven;
 
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
 import scala_maven_executions.JavaMainCaller;
 
 
 /**
  * Display the Scala Compiler help
  *
- * @goal help
  */
+@Mojo(name = "help")
 public class ScalaHelpMojo extends ScalaMojoSupport {
     /**
      * Determines if help will only display a version
      *
-     * @parameter property="maven.scala.help.versionOnly" default-value="false"
      */
+    @Parameter(property="maven.scala.help.versionOnly", defaultValue="false")
     private boolean versionOnly;
 
     @Override

--- a/src/main/java/scala_maven/ScalaRunMojo.java
+++ b/src/main/java/scala_maven/ScalaRunMojo.java
@@ -1,5 +1,10 @@
 package scala_maven;
 
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.toolchain.Toolchain;
 import org.codehaus.plexus.util.StringUtils;
 
@@ -7,34 +12,34 @@ import scala_maven_executions.JavaMainCaller;
 import scala_maven_executions.JavaMainCallerByFork;
 import scala_maven_executions.MainHelper;
 
-
 /**
  * Run a Scala class using the Scala runtime
  *
- * @goal run
- * @requiresDependencyResolution test
- * @execute phase="test-compile"
- * @threadSafe
  */
+@Mojo(name = "run", requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
+@Execute(phase = LifecyclePhase.TEST_COMPILE)
 public class ScalaRunMojo extends ScalaMojoSupport {
 
     /**
      * The class to use when launching a scala program
      *
-     * @parameter property="launcher"
      */
+    @Parameter(property = "launcher")
     protected String launcher;
 
     /**
      * Additional parameter to use to call the main class
-     * Using this parameter only from command line ("-DaddArgs=arg1|arg2|arg3|..."), not from pom.xml.
-     * @parameter property="addArgs"
+     * Using this parameter only from command line ("-DaddArgs=arg1|arg2|arg3|..."),
+     * not from pom.xml.
      */
+    @Parameter(property = "addArgs")
     protected String addArgs;
 
     /**
-     * A list of launcher definition (to avoid rewriting long command line or share way to call an application)
+     * A list of launcher definition (to avoid rewriting long command line or share
+     * way to call an application)
      * launchers could be define by :
+     * 
      * <pre>
      *   &lt;launchers>
      *     &lt;launcher>
@@ -54,17 +59,21 @@ public class ScalaRunMojo extends ScalaMojoSupport {
      *     &lt;/launcher>
      *   &lt;/launchers>
      * </pre>
-     * @parameter
+     * 
      */
+    @Parameter
     protected Launcher[] launchers;
 
     /**
-     * Main class to call, the call use the jvmArgs and args define in the pom.xml, and the addArgs define in the command line if define.
+     * Main class to call, the call use the jvmArgs and args define in the pom.xml,
+     * and the addArgs define in the command line if define.
      *
      * Higher priority to launcher parameter)
-     * Using this parameter only from command line (-DmainClass=...), not from pom.xml.
-     * @parameter property="mainClass"
+     * Using this parameter only from command line (-DmainClass=...), not from
+     * pom.xml.
+     * 
      */
+    @Parameter(property="mainClass")
     protected String mainClass;
 
     @Override

--- a/src/main/java/scala_maven/ScalaScriptMojo.java
+++ b/src/main/java/scala_maven/ScalaScriptMojo.java
@@ -26,6 +26,9 @@ import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.classworlds.ClassWorld;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
@@ -37,16 +40,12 @@ import org.codehaus.plexus.util.StringUtils;
 import scala_maven_executions.JavaMainCaller;
 import scala_maven_executions.MainHelper;
 
-
 /**
  * Run a scala script.
  *
- * @goal script
- * @requiresDependencyResolution runtime
- * @executionStrategy always
  * @since 2.7
- * @threadSafe
  */
+@Mojo(name = "script", requiresDependencyResolution = ResolutionScope.RUNTIME, executionStrategy = "always", threadSafe = true)
 public class ScalaScriptMojo extends ScalaMojoSupport {
 
     /*
@@ -57,31 +56,31 @@ public class ScalaScriptMojo extends ScalaMojoSupport {
     /**
      * The build directory of the project
      *
-     * @parameter property="project.build.directory"
      */
+    @Parameter(property = "project.build.directory")
     protected File outputDir;
 
     /**
      * The file containing script to be executed. Either '<em>scriptFile</em>'
      * or '<em>script</em>' must be defined.
      *
-     * @parameter property="scriptFile"
      */
+    @Parameter(property = "scriptFile")
     protected File scriptFile;
 
     /**
      * The encoding of file containing script to be executed.
      *
-     * @parameter property="scriptEncoding" default-value="UTF-8"
      */
+    @Parameter(property = "scriptEncoding", defaultValue = "UTF-8")
     protected String scriptEncoding;
 
     /**
      * The script that will be executed. Either '<em>scriptFile</em>' or '
      * <em>script</em>' must be defined.
      *
-     * @parameter property="script"
      */
+    @Parameter(property = "script")
     protected String script;
 
     /**
@@ -90,9 +89,8 @@ public class ScalaScriptMojo extends ScalaMojoSupport {
      * script especially since line numbers will be wrong because lines are
      * added to the compiled script (see script examples)
      *
-     * @parameter property="maven.scala.keepGeneratedScript"
-     *            default-value="false"
      */
+    @Parameter(property = "maven.scala.keepGeneratedScript", defaultValue = "false")
     protected boolean keepGeneratedScript;
 
     /**
@@ -101,23 +99,23 @@ public class ScalaScriptMojo extends ScalaMojoSupport {
      * By default embedded script into pom.xml run with 'plugin' scope
      * and script read from scriptFile run with 'compile, test, runtime'
      *
-     * @parameter property="maven.scala.includeScopes"
      */
+    @Parameter(property = "maven.scala.includeScopes")
     protected String includeScopes;
 
     /**
      * Comma separated list of scopes to remove from the classpath. Eg:
      * test,compile
      *
-     * @parameter property="maven.scala.excludeScopes"
      */
+    @Parameter(property = "maven.scala.excludeScopes")
     protected String excludeScopes;
 
     /**
      * Comma seperated list of directories or jars to add to the classpath
      *
-     * @parameter property="addToClasspath"
      */
+    @Parameter(property="addToClasspath")
     protected String addToClasspath;
 
     /**
@@ -126,8 +124,8 @@ public class ScalaScriptMojo extends ScalaMojoSupport {
      * script uses Ant 1.7 and the compiler dependencies pull in Ant 1.5
      * optional which conflicts and causes a crash
      *
-     * @parameter property="removeFromClasspath"
      */
+    @Parameter(property="removeFromClasspath")
     protected String removeFromClasspath;
 
     private static AtomicInteger _lastScriptIndex = new AtomicInteger(0);

--- a/src/main/java/scala_maven/ScalaSourceMojoSupport.java
+++ b/src/main/java/scala_maven/ScalaSourceMojoSupport.java
@@ -1,13 +1,15 @@
 package scala_maven;
 
-import scala_maven_executions.MainHelper;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+import scala_maven_executions.MainHelper;
 
 /**
  * @author david.bernard
@@ -17,8 +19,8 @@ abstract public class ScalaSourceMojoSupport extends ScalaMojoSupport {
     /**
      * Enables/Disables sending java source to the scala compiler.
      *
-     * @parameter default-value="true"
      */
+    @Parameter(defaultValue="true")
     protected boolean sendJavaToScalac = true;
 
     /**
@@ -30,8 +32,8 @@ abstract public class ScalaSourceMojoSupport extends ScalaMojoSupport {
      *    &lt;/includes&gt;
      * </pre>
      *
-     * @parameter
      */
+    @Parameter
     protected Set<String> includes = new HashSet<String>();
 
     /**
@@ -43,8 +45,8 @@ abstract public class ScalaSourceMojoSupport extends ScalaMojoSupport {
      *    &lt;/excludes&gt;
      * </pre>
      *
-     * @parameter
      */
+    @Parameter
     protected Set<String> excludes = new HashSet<String>();
 
     /**

--- a/src/main/java/scala_maven/ScalaTestCompileMojo.java
+++ b/src/main/java/scala_maven/ScalaTestCompileMojo.java
@@ -6,38 +6,40 @@ import java.util.List;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
- * Compile Scala test source into test-classes.  Corresponds roughly to testCompile
+ * Compile Scala test source into test-classes. Corresponds roughly to
+ * testCompile
  * in maven-compiler-plugin
  *
- * @phase test-compile
- * @goal testCompile
- * @requiresDependencyResolution test
- * @threadSafe
  */
+@Mojo(name = "testCompile", defaultPhase = LifecyclePhase.TEST_COMPILE, requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
 public class ScalaTestCompileMojo extends ScalaCompilerSupport {
 
     /**
      * Set this to 'true' to bypass unit tests entirely.
      * Its use is NOT RECOMMENDED, but quite convenient on occasion.
      *
-     * @parameter property="maven.test.skip"
      */
+    @Parameter(property = "maven.test.skip")
     protected boolean skip;
 
     /**
      * The directory in which to place test compilation output
      *
-     * @parameter default-value="${project.build.testOutputDirectory}
      */
+    @Parameter(defaultValue="${project.build.testOutputDirectory}")
     protected File testOutputDir;
 
     /**
      * The directory in which to find test scala source code
      *
-     * @parameter default-value="${project.build.testSourceDirectory}/../scala"
      */
+    @Parameter(defaultValue="${project.build.testSourceDirectory}/../scala")
     protected File testSourceDir;
 
     @Override
@@ -51,8 +53,8 @@ public class ScalaTestCompileMojo extends ScalaCompilerSupport {
     /**
      * Analysis cache file for incremental recompilation.
      *
-     * @parameter property="testAnalysisCacheFile" default-value="${project.build.directory}/analysis/test-compile"
      */
+    @Parameter(property="testAnalysisCacheFile", defaultValue="${project.build.directory}/analysis/test-compile")
     protected File testAnalysisCacheFile;
 
     @Override


### PR DESCRIPTION
The two main reasons for this move:

1. It is partially checked by the compiler

2. It makes interoperability easier, as the Java annotations were preserved in the classfiles whereas the javadoc-annoations were not.
E.g. The bloop project has a maven plugin which inherits from some base classes of this plugin to read it's configuration.
After this change, the maven plugin build just works, but before, it couldn't see any `@parameter` and `@component` comments, which is a real pain.

Cutting a release after merge would be very much appreciated.