### PR TITLE
`doc-jar` passes no classpath to scaladoc

### DIFF
--- a/src/main/java/scala_maven/ScalaDocJarMojo.java
+++ b/src/main/java/scala_maven/ScalaDocJarMojo.java
@@ -14,6 +14,7 @@ import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProjectHelper;
 import org.apache.maven.reporting.MavenReportException;
 import org.codehaus.plexus.archiver.Archiver;
@@ -26,7 +27,7 @@ import org.codehaus.plexus.archiver.jar.ManifestException;
  * to the project for distribution.
  *
  */
-@Mojo(name = "doc-jar", defaultPhase = LifecyclePhase.PACKAGE)
+@Mojo(name = "doc-jar", defaultPhase = LifecyclePhase.PACKAGE, requiresDependencyResolution = ResolutionScope.COMPILE)
 public class ScalaDocJarMojo extends ScalaDocMojo {
 
     private static final String[] DEFAULT_INCLUDES = new String[] { "**/**" };


### PR DESCRIPTION
Beginning with d9f45d0, the doc-jar goal (ScalaDocJarMojo) was not passing a classpath to scaladoc. When running on Java 8, scaladoc reported errors wherever any symbol from a dependency is mentioned (e.g. “object log4s is not a member of package org”, even though log4s is supposed to be on the classpath). When running on Java 10, scaladoc suffered an immediate fatal error instead (“object scala in compiler mirror not found”).

Here's an example args file, demonstrating the problem:

```
-Xlint
-doc-format:html
-doc-title
"Find install4j Library 1.1-SNAPSHOT API"
-d
"C:\Users\[user]\Documents\find-install4j\target\site\scaladocs"
"C:\Users\[user]\Documents\find-install4j\src\main\scala\com\valuadder\util\findinstall4j\ComponentFinder.scala"
"C:\Users\[user]\Documents\find-install4j\src\main\scala\com\valuadder\util\findinstall4j\DiscoveryMethod.scala"
"C:\Users\[user]\Documents\find-install4j\src\main\scala\com\valuadder\util\findinstall4j\Install4jResourceCollection.scala"
"C:\Users\[user]\Documents\find-install4j\src\main\scala\com\valuadder\util\findinstall4j\package.scala"
```

The problem was that ScalaDocJarMojo did not declare that it `requiresDependencyResolution`. In the legacy Javadoc-style annotations for Maven plugins, `@requiresDependencyResolution` is a separate, inherited annotation, so ScalaDocJarMojo inherited it from ScalaDocMojo. With the new annotations, however, `requiresDependencyResolution` is instead a field of the `@Mojo` annotation, which is *not* inherited.

This PR fixes that.