### PR TITLE
Add compiler plugins to scaladoc execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -579,7 +579,7 @@
                 <scala.version.28>2.8.2</scala.version.28>
                 <scala.version.lastrelease>2.12.6</scala.version.lastrelease>
                 <scala.version.next>2.12.6</scala.version.next>
-                <scala.version.minor>2.12</scala.version.minor>
+                <scala.version.binary>2.12</scala.version.binary>
                 <scala.macroparadise.version>2.10.2-SNAPSHOT</scala.macroparadise.version>
                 <scala.macroparadise.organisation>org.scala-lang.macro-paradise</scala.macroparadise.organisation>
               </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -579,6 +579,7 @@
                 <scala.version.28>2.8.2</scala.version.28>
                 <scala.version.lastrelease>2.12.6</scala.version.lastrelease>
                 <scala.version.next>2.12.6</scala.version.next>
+                <scala.version.minor>2.12</scala.version.minor>
                 <scala.macroparadise.version>2.10.2-SNAPSHOT</scala.macroparadise.version>
                 <scala.macroparadise.organisation>org.scala-lang.macro-paradise</scala.macroparadise.organisation>
               </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -579,7 +579,7 @@
                 <scala.version.28>2.8.2</scala.version.28>
                 <scala.version.lastrelease>2.12.6</scala.version.lastrelease>
                 <scala.version.next>2.12.6</scala.version.next>
-                <scala.version.binary>2.12</scala.version.binary>
+                <scala.compat.version>2.12</scala.compat.version>
                 <scala.macroparadise.version>2.10.2-SNAPSHOT</scala.macroparadise.version>
                 <scala.macroparadise.organisation>org.scala-lang.macro-paradise</scala.macroparadise.organisation>
               </properties>

--- a/src/it/test_scaladoc_compiler_plugins/invoker.properties
+++ b/src/it/test_scaladoc_compiler_plugins/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean package -e

--- a/src/it/test_scaladoc_compiler_plugins/pom.xml
+++ b/src/it/test_scaladoc_compiler_plugins/pom.xml
@@ -48,7 +48,7 @@
           <compilerPlugins>
             <compilerPlugin>
               <groupId>org.spire-math</groupId>
-              <artifactId>kind-projector_${scala.version.binary}</artifactId>
+              <artifactId>kind-projector_${scala.compat.version}</artifactId>
               <version>0.9.4</version>
             </compilerPlugin>
           </compilerPlugins>

--- a/src/it/test_scaladoc_compiler_plugins/pom.xml
+++ b/src/it/test_scaladoc_compiler_plugins/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>it.scala-maven-plugin</groupId>
+  <artifactId>test_scaladoc_compiler_plugin</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <displayCmd>true</displayCmd>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>${scala.version.lastrelease}</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <args>
+            <arg>-explaintypes</arg>
+            <arg>-deprecation</arg>
+            <arg>-feature</arg>
+            <arg>-unchecked</arg>
+            <arg>-Xcheckinit</arg>
+            <arg>-Xlint</arg>
+            <arg>-Ypartial-unification</arg>
+            <arg>-Ywarn-adapted-args</arg>
+            <arg>-Ywarn-dead-code</arg>
+            <arg>-Ywarn-inaccessible</arg>
+            <arg>-Ywarn-infer-any</arg>
+            <arg>-Ywarn-nullary-override</arg>
+            <arg>-Ywarn-nullary-unit</arg>
+            <arg>-Ywarn-numeric-widen</arg>
+            <arg>-Ywarn-unused</arg>
+            <arg>-Ywarn-unused-import</arg>
+            <arg>-Ywarn-value-discard</arg>
+          </args>
+          <compilerPlugins>
+            <compilerPlugin>
+              <groupId>org.spire-math</groupId>
+              <artifactId>kind-projector_${scala.version.minor}</artifactId>
+              <version>0.9.4</version>
+            </compilerPlugin>
+          </compilerPlugins>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>doc-jar</goal>
+            </goals>
+          </execution>       
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/test_scaladoc_compiler_plugins/pom.xml
+++ b/src/it/test_scaladoc_compiler_plugins/pom.xml
@@ -48,7 +48,7 @@
           <compilerPlugins>
             <compilerPlugin>
               <groupId>org.spire-math</groupId>
-              <artifactId>kind-projector_${scala.version.minor}</artifactId>
+              <artifactId>kind-projector_${scala.version.binary}</artifactId>
               <version>0.9.4</version>
             </compilerPlugin>
           </compilerPlugins>

--- a/src/it/test_scaladoc_compiler_plugins/src/main/scala/MyClass.scala
+++ b/src/it/test_scaladoc_compiler_plugins/src/main/scala/MyClass.scala
@@ -1,0 +1,9 @@
+import scala.language.higherKinds
+
+object MyClass {
+
+  class TestKinded[F[_], G]
+
+  def testWithHigherKinded[F[_] : TestKinded[?[_], Int]] = ???
+
+}

--- a/src/it/test_scaladoc_compiler_plugins/validate.groovy
+++ b/src/it/test_scaladoc_compiler_plugins/validate.groovy
@@ -1,0 +1,14 @@
+try {
+
+def file = new File(basedir, 'target/classes/MyClass.class')
+assert file.exists()
+
+def file2 = new File(basedir, 'target/classes/MyClass$.class')
+assert file2.exists()
+
+return true
+
+} catch(Throwable e) {
+  e.printStackTrace()
+  return false
+}

--- a/src/main/java/scala_maven/ScalaDocMojo.java
+++ b/src/main/java/scala_maven/ScalaDocMojo.java
@@ -296,6 +296,7 @@ public class ScalaDocMojo extends ScalaSourceMojoSupport implements MavenReport 
         JavaMainCaller jcmd = getEmptyScalaCommand(scaladocClassName);
         jcmd.addArgs(args);
         jcmd.addJvmArgs(jvmArgs);
+        addCompilerPluginOptions(jcmd);
 
         if (isPreviousScala271){
             jcmd.addArgs("-Ydoc");


### PR DESCRIPTION
I have been unable to use `kind-projector` in much of my code while still producing scaladoc because the `-Xplugin` option has not been included when invoking scaladoc. This means that the build fails, so I was left with the choice of having type aliases or not generating documentation. 

This PR fixes this issue by adding the compiler plugin arguments to the scaladoc execution. An integration test has been added to verify that it works. Note that I used `kind-projector` in the sample project, which required adding a new property (`scala.version.binary`) to the top-level `pom.xml` that tracks the latest binary-compatible version for appending to any library artifacts. 