### PR TITLE
DO NOT MERGE Enable incremental mode by default

### DIFF
--- a/src/it/test_directory_with_class_name/pom.xml
+++ b/src/it/test_directory_with_class_name/pom.xml
@@ -30,15 +30,15 @@
 					<artifactId>@project.artifactId@</artifactId>
 					<version>@project.version@</version>
 					<configuration>
-						<!--recompileMode>incremental</recompileMode-->
+						<recompileMode>all</recompileMode>
 						<args>
-							<arg>-target:jvm-1.7</arg>
+							<arg>-target:jvm-1.8</arg>
 						</args>
 						<javacArgs>
 							<javacArg>-source</javacArg>
-							<javacArg>1.7</javacArg>
+							<javacArg>1.8</javacArg>
 							<javacArg>-target</javacArg>
-							<javacArg>1.7</javacArg>
+							<javacArg>1.8</javacArg>
 						</javacArgs>
           			</configuration>
 				</plugin>

--- a/src/main/java/sbt_inc/SbtIncrementalCompiler.java
+++ b/src/main/java/sbt_inc/SbtIncrementalCompiler.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class SbtIncrementalCompiler {
 
@@ -58,7 +59,7 @@ public class SbtIncrementalCompiler {
 
         compiler = new IncrementalCompilerImpl();
 
-        AnalyzingCompiler scalaCompiler = new AnalyzingCompiler(
+        ScalaCompiler scalaCompiler = new AnalyzingCompiler(
             scalaInstance, // scalaInstance
             ZincCompilerUtil.constantBridgeProvider(scalaInstance, compilerBridgeJar), //provider
             ClasspathOptionsUtil.auto(), // classpathOptions
@@ -99,9 +100,11 @@ public class SbtIncrementalCompiler {
     }
 
     public void compile(List<String> classpathElements, List<File> sources, File classesDirectory, List<String> scalacOptions, List<String> javacOptions) {
+        List<File> fullClasspath = classpathElements.stream().map(File::new).collect(Collectors.toList());
+        fullClasspath.add(classesDirectory);
 
         Inputs inputs = compiler.inputs(
-            classpathElements.stream().map(File::new).toArray(size -> new File[size]), //classpath
+            fullClasspath.toArray(new File[]{}), //classpath
             sources.toArray(new File[]{}), // sources
             classesDirectory, // classesDirectory
             scalacOptions.toArray(new String[]{}), // scalacOptions

--- a/src/main/java/sbt_inc/SbtIncrementalCompiler.java
+++ b/src/main/java/sbt_inc/SbtIncrementalCompiler.java
@@ -100,8 +100,11 @@ public class SbtIncrementalCompiler {
     }
 
     public void compile(List<String> classpathElements, List<File> sources, File classesDirectory, List<String> scalacOptions, List<String> javacOptions) {
-        List<File> fullClasspath = classpathElements.stream().map(File::new).collect(Collectors.toList());
+        List<File> fullClasspath = new ArrayList<>();
         fullClasspath.add(classesDirectory);
+        for (String classpathElement : classpathElements) {
+            fullClasspath.add(new File(classpathElement));
+        }
 
         Inputs inputs = compiler.inputs(
             fullClasspath.toArray(new File[]{}), //classpath

--- a/src/main/java/scala_maven/ScalaCompilerSupport.java
+++ b/src/main/java/scala_maven/ScalaCompilerSupport.java
@@ -31,8 +31,8 @@ public abstract class ScalaCompilerSupport extends ScalaSourceMojoSupport {
      * sources.
      *
      */
-    @Parameter(property = "recompileMode", defaultValue = "all")
-    protected String recompileMode = ALL;
+    @Parameter(property = "recompileMode", defaultValue = "incremental")
+    protected String recompileMode;
 
     /**
      * notifyCompilation if true then print a message "path: compiling"
@@ -42,7 +42,7 @@ public abstract class ScalaCompilerSupport extends ScalaSourceMojoSupport {
      *
      */
     @Parameter(property = "notifyCompilation", defaultValue = "true")
-    private boolean notifyCompilation = true;
+    private boolean notifyCompilation;
 
     abstract protected File getOutputDir() throws Exception;
 

--- a/src/main/java/scala_maven/ScalaCompilerSupport.java
+++ b/src/main/java/scala_maven/ScalaCompilerSupport.java
@@ -90,12 +90,8 @@ public abstract class ScalaCompilerSupport extends ScalaSourceMojoSupport {
 
     protected int compile(List<File> sourceRootDirs, File outputDir, File analysisCacheFile, List<String> classpathElements, boolean compileInLoop) throws Exception, InterruptedException {
         if (!compileInLoop && INCREMENTAL.equals(recompileMode)) {
-            // TODO - Do we really need this duplicated here?
-            if (!outputDir.exists()) {
-              outputDir.mkdirs();
-            }
             // if not compileInLoop, invoke incrementalCompile immediately
-            return incrementalCompile(classpathElements, sourceRootDirs, outputDir, analysisCacheFile, compileInLoop);
+            return incrementalCompile(classpathElements, sourceRootDirs, outputDir, analysisCacheFile, false);
         }
 
         long t0 = System.currentTimeMillis();
@@ -249,6 +245,11 @@ public abstract class ScalaCompilerSupport extends ScalaSourceMojoSupport {
         List<File> sources = findSourceWithFilters(sourceRootDirs);
         if (sources.isEmpty()) {
             return -1;
+        }
+
+        // TODO - Do we really need this duplicated here?
+        if (!outputDir.exists()) {
+            outputDir.mkdirs();
         }
 
         if (incremental == null) {


### PR DESCRIPTION
I'm trying to enable incremental compiler by default.

The IT tests that test that `Mixed` compile order against Java/Scala circular references all fail.
Note that those tests pass when using non incremental (`all`) mode that launch a scalac process.

@jvican I'm a bit at a loss here. Could you please help?

