### PR TITLE
Partial revert of e2ce8b3759a581f32593a56bac100a1a51a68966 protected => private API changes for bloop/other 3rd party apps

### DIFF
--- a/src/main/java/scala_maven/ScalaContinuousCompileMojo.java
+++ b/src/main/java/scala_maven/ScalaContinuousCompileMojo.java
@@ -24,65 +24,73 @@ public class ScalaContinuousCompileMojo extends ScalaCompilerSupport {
      *
      */
     @Parameter(property = "project.build.outputDirectory")
-    private File mainOutputDir;
+    protected File mainOutputDir;
 
     /**
      * The main directory containing scala source for compilation
      *
+     * Note: Allows extending for 3rd-party usages
      */
     @Parameter(defaultValue = "${project.build.sourceDirectory}/../scala")
-    private File mainSourceDir;
+    protected File mainSourceDir;
 
     /**
      * The directory to place test compilation output in
      *
+     * Note: Allows extending for 3rd-party usages
      */
     @Parameter(defaultValue = "${project.build.testOutputDirectory}")
-    private File testOutputDir;
+    protected File testOutputDir;
 
     /**
      * The directory containing test source for compilation
      *
+     * Note: Allows extending for 3rd-party usages
      */
     @Parameter(defaultValue = "${project.build.testSourceDirectory}/../scala")
-    private File testSourceDir;
+    protected File testSourceDir;
 
     /**
      * Analysis cache file for incremental recompilation.
      *
+     * Note: Allows extending for 3rd-party usages
      */
     @Parameter(property = "analysisCacheFile", defaultValue = "${project.build.directory}/analysis/compile")
-    private File analysisCacheFile;
+    protected File analysisCacheFile;
 
     /**
      * Analysis cache file for incremental recompilation.
      *
+     * Note: Allows extending for 3rd-party usages
      */
     @Parameter(property = "testAnalysisCacheFile", defaultValue = "${project.build.directory}/analysis/test-compile")
-    private File testAnalysisCacheFile;
+    protected File testAnalysisCacheFile;
 
     /**
      * Define if fsc should be used, else scalac is used. fsc =>
      * scala.tools.nsc.CompileClient, scalac =&gt; scala.tools.nsc.Main.
      *
+     * Note: Allows extending for 3rd-party usages
      */
     @Parameter(property = "fsc", defaultValue = "true")
-    private boolean useFsc;
+    protected boolean useFsc;
 
     /**
      * Define if cc should run once or in infinite loop. (useful for test or working
      * with editor)
      *
+     * Note: Allows extending for 3rd-party usages
      */
     @Parameter(property = "once", defaultValue = "false")
-    private boolean once;
+    protected boolean once;
 
     /**
      * Turns verbose output on.
      *
+     * Note: Allows extending for 3rd-party usages
      */
     @Parameter(property = "verbose", defaultValue = "false")
-    private boolean verbose;
+    protected boolean verbose;
 
     @Override
     protected List<String> getClasspathElements() {

--- a/src/main/java/scala_maven/ScalaMojoSupport.java
+++ b/src/main/java/scala_maven/ScalaMojoSupport.java
@@ -77,9 +77,10 @@ public abstract class ScalaMojoSupport extends AbstractMojo {
     /**
      * The Maven Session Object
      *
+     * Note: Allows extending for 3rd-party usages
      */
     @Parameter(property = "session", required = true, readonly = true)
-    MavenSession session;
+    protected MavenSession session;
 
     /**
      * Used to look up Artifacts in the remote repository.


### PR DESCRIPTION


This API change: https://github.com/davidB/scala-maven-plugin/commit/e2ce8b3759a581f32593a56bac100a1a51a68966#diff-2660d2ba8fa58383b0f754f4a4155f71L25 changing the members from protected to private kinda messes up: https://github.com/scalacenter/bloop/blob/master/integrations/maven-bloop/src/main/java/scala_maven/ExtendedScalaContinuousCompileMojo.java

`session` was also needed in `ScalaMojoSupport`

I've verified I can compile `bloop` with these changes.

Regards,

Eric