### PR TITLE
Upgrade Zinc 1.3.0-M7, support Scala 2.13.0, close #346

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@
     <dependency>
       <groupId>org.scala-sbt</groupId>
       <artifactId>zinc_2.12</artifactId>
-      <version>1.2.5</version>
+      <version>1.3.0-M7</version>
     </dependency>
     <dependency>
       <groupId>org.scala-lang.modules</groupId>


### PR DESCRIPTION
Motivation:

We use precompile Zinc compiler-bridge.
Alas, `org.scala-sbt:compiler-bridge_2.13:1.2.5` as deployed on maven central is actually compiled against Scala 2.13.0-M2, so it crashes when trying to compile with Scala 2.13.0 as the Collection API was revamped since then.

Modification:

* Upgrade Zinc 1.3.0-M7 whose compiler-bridge is properly compiled against Scala 2.13.0.
* minor previousResult configuration clean up

Result:

scala-maven-plugin now supports Scala 2.13 (stable).