### PR TITLE
Misc incremental compiler clean up

### DIFF
--- a/src/main/java/scala_maven/ScalaCompilerSupport.java
+++ b/src/main/java/scala_maven/ScalaCompilerSupport.java
@@ -252,6 +252,16 @@ public abstract class ScalaCompilerSupport extends ScalaSourceMojoSupport {
     //
     // Incremental compilation
     //
+    private static final String SBT_GROUP_ID = "org.scala-sbt";
+    private static final String ZINC_ARTIFACT_ID = "zinc_2.12";
+    private static final String COMPILER_BRIDGE_ARTIFACT_ID = "compiler-bridge";
+
+    protected File getCompilerBridgeJar() throws Exception {
+        VersionNumber scalaVersion = findScalaVersion();
+        String zincVersion = findVersionFromPluginArtifacts(SBT_GROUP_ID, ZINC_ARTIFACT_ID);
+        return getArtifactJar(SBT_GROUP_ID,
+            scalaVersion.applyScalaArtifactVersioningScheme(COMPILER_BRIDGE_ARTIFACT_ID), zincVersion);
+    }
 
     private int incrementalCompile(List<String> classpathElements, List<File> sourceRootDirs, File outputDir,
         File cacheFile, boolean compileInLoop) throws Exception {
@@ -267,13 +277,18 @@ public abstract class ScalaCompilerSupport extends ScalaSourceMojoSupport {
 
         if (incremental == null) {
             File libraryJar = getLibraryJar();
-            File reflectJar = getReflectJar();
-            File compilerJar = getCompilerJar();
             List<File> extraJars = getCompilerDependencies();
             extraJars.remove(libraryJar);
-            File compilerBridgeJar = getCompilerBridgeJar();
-            incremental = new SbtIncrementalCompiler(libraryJar, reflectJar, compilerJar, findScalaVersion(), extraJars,
-                compilerBridgeJar, getLog(), cacheFile, compileOrder);
+            incremental = new SbtIncrementalCompiler(//
+                libraryJar, //
+                getReflectJar(), //
+                getCompilerJar(), //
+                findScalaVersion(), //
+                extraJars, //
+                getCompilerBridgeJar(), //
+                getLog(), //
+                cacheFile, //
+                compileOrder);
         }
 
         classpathElements.remove(outputDir.getAbsolutePath());

--- a/src/main/java/scala_maven/ScalaMojoSupport.java
+++ b/src/main/java/scala_maven/ScalaMojoSupport.java
@@ -883,15 +883,6 @@ public abstract class ScalaMojoSupport extends AbstractMojo {
         return getArtifactJar(getScalaOrganization(), SCALA_COMPILER_ARTIFACTID, findScalaVersion().toString());
     }
 
-    protected File getCompilerBridgeJar() throws Exception {
-        VersionNumber scalaVersion = findScalaVersion();
-        String zincVersion = findVersionFromPluginArtifacts(SbtIncrementalCompiler.SBT_GROUP_ID,
-            SbtIncrementalCompiler.ZINC_ARTIFACT_ID);
-        return getArtifactJar(SbtIncrementalCompiler.SBT_GROUP_ID,
-            scalaVersion.applyScalaArtifactVersioningScheme(SbtIncrementalCompiler.COMPILER_BRIDGE_ARTIFACT_ID),
-            zincVersion);
-    }
-
     protected List<File> getCompilerDependencies() throws Exception {
         List<File> d = new ArrayList<>();
         if (StringUtils.isEmpty(scalaHome)) {
@@ -910,7 +901,7 @@ public abstract class ScalaMojoSupport extends AbstractMojo {
         return d;
     }
 
-    private File getArtifactJar(String groupId, String artifactId, String version) throws Exception {
+    protected File getArtifactJar(String groupId, String artifactId, String version) throws Exception {
         Artifact artifact = factory.createArtifact(groupId, artifactId, version, Artifact.SCOPE_RUNTIME,
             ScalaMojoSupport.JAR);
         resolver.resolve(artifact, remoteRepos, localRepo);
@@ -940,7 +931,7 @@ public abstract class ScalaMojoSupport extends AbstractMojo {
 
     /**
      * Adds appropriate compiler plugins to the scalac command.
-     * 
+     *
      * @param scalac
      * @throws Exception
      */
@@ -984,7 +975,7 @@ public abstract class ScalaMojoSupport extends AbstractMojo {
         return plugins;
     }
 
-    private String findVersionFromPluginArtifacts(String groupId, String artifactId) {
+    protected String findVersionFromPluginArtifacts(String groupId, String artifactId) {
         for (Artifact art : pluginArtifacts) {
             if (groupId.equals(art.getGroupId()) && artifactId.equals(art.getArtifactId())) {
                 return art.getVersion();


### PR DESCRIPTION
* Stop using IncrementalCompilerImpl, use ZincUtil.defaultIncrementalCompiler that returns an IncrementalCompiler and directly create other components (compiler, setup, emptyPreviousResult) instead of using IncrementalCompilerImpl methods.
* Move SbtIncrementalCompiler constants to ScalaCompilerSupport where they are actually used
* Move getCompilerBridgeJar to ScalaCompilerSupport where it's actually used