### PR TITLE
Allow to omit -target and -source options in javac

### DIFF
--- a/src/main/java/scala_maven/ScalaMojoSupport.java
+++ b/src/main/java/scala_maven/ScalaMojoSupport.java
@@ -844,11 +844,11 @@ public abstract class ScalaMojoSupport extends AbstractMojo {
         if (javacGenerateDebugSymbols) {
             options.add("-g");
         }
-        if (target != null) {
+        if (target != null && !target.isEmpty()) {
             options.add("-target");
             options.add(target);
         }
-        if (source != null) {
+        if (source != null && !source.isEmpty()) {
             options.add("-source");
             options.add(source);
         }


### PR DESCRIPTION
This PR proposes to allow to omit `-target` and `-source` options in javac.

```
[debug] Forking javac: /.../bin/javac @/.../argfile
[error] error: option -source cannot be used together with --release
[error] error: option -target cannot be used together with --release
[error] Usage: javac <options> <source files>
[error] use --help for a list of possible options
[debug] javac returned exit code: 2
```

I am trying to cross-compile with `--release` option in JDK 11; however, due to added `-source` and `-target`, seems unable to do it.

_Note that_ if corresponding properties are not set, it seems setting default values to the properties (see https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html) instead of setting it as `null`. So there look no way to set `target` and `source` to `null`.

So, this PR provides a way to omit it via specifying empty property values. e.g.

```xml
      <properties>
        <maven.compiler.source/>
        <maven.compiler.target/>
      </properties>
```

It is backwards compatible - before this fix:

```
[debug] Forking javac: /.../javac @/.../argfile
[error] error: invalid target release:
[error] Usage: javac <options> <source files>
[error] use --help for a list of possible options
[debug] javac returned exit code: 2
```