### PR TITLE
Issue-379: Can't use user property outputDir from the command line

### DIFF
--- a/src/main/java/scala_maven/ScalaCompileMojo.java
+++ b/src/main/java/scala_maven/ScalaCompileMojo.java
@@ -21,7 +21,7 @@ public class ScalaCompileMojo extends ScalaCompilerSupport {
     /**
      * The directory in which to place compilation output
      */
-    @Parameter(property = "project.build.outputDirectory")
+    @Parameter(property = "outputDir", defaultValue = "${project.build.outputDirectory}")
     private File outputDir;
 
     /**


### PR DESCRIPTION
Fix implemented as outlined in the [issue](https://github.com/davidB/scala-maven-plugin/issues/379). Test in an Apache James subproject:

```
C:\ws414\james\server\task\task-api>mvn scala:compile -DoutputDir=target-scala
[INFO] Scanning for projects...
[INFO]
[INFO] ---------------< org.apache.james:james-server-task-api >---------------
[INFO] Building Apache James :: Server :: Task :: API 3.5.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
(...)
[INFO] Compiling 2 Scala sources and 5 Java sources to 
       C:\ws414\james\server\task\task-api\target-scala ...
```

Testing default behaviour:

```
C:\ws414\james\server\task\task-api>mvn scala:compile
[INFO] Scanning for projects...
[INFO]
[INFO] ---------------< org.apache.james:james-server-task-api >---------------
[INFO] Building Apache James :: Server :: Task :: API 3.5.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
(...)
[INFO] Compiling 2 Scala sources and 5 Java sources to
       C:\ws414\james\server\task\task-api\target\classes ...
```

