### PR TITLE
Remove log-level prefix from incoming Sbt log messages

### DIFF
--- a/src/main/java/sbt_inc/SbtLogger.java
+++ b/src/main/java/sbt_inc/SbtLogger.java
@@ -30,14 +30,19 @@ public class SbtLogger extends Logger {
 
     @Override
     public void log(Enumeration.Value level, Function0<String> message) {
+        String s = message.apply();
+        String prefix = "[" + level.toString() + "] ";
+        if (s.regionMatches(true, 0, prefix, 0, prefix.length())) {
+            s = s.substring(prefix.length());
+        }
         if (level.equals(Level.Error())) {
-            log.error(message.apply());
+            log.error(s);
         } else if (level.equals(Level.Warn())) {
-            log.warn(message.apply());
+            log.warn(s);
         } else if (level.equals(Level.Info())) {
-            log.info(message.apply());
+            log.info(s);
         } else if (level.equals(Level.Debug())) {
-            log.debug(message.apply());
+            log.debug(s);
         }
     }
 }


### PR DESCRIPTION
To avoid a double log-level prefix to all messages, remove the one coming in
from Sbt.  The one that Maven generates will do fine.