### PR TITLE
Update Zinc information in documentation site

### DIFF
--- a/src/site/xdoc/example_incremental.xml.vm
+++ b/src/site/xdoc/example_incremental.xml.vm
@@ -8,7 +8,7 @@
 
     <p>
       Incremental compilation is supported using
-      <a href="https://github.com/typesafehub/zinc">Zinc</a>,
+      <a href="https://github.com/sbt/zinc">Zinc</a>,
       a stand-alone version of sbt's incremental compiler.
     </p>
 

--- a/src/site/xdoc/example_incremental.xml.vm
+++ b/src/site/xdoc/example_incremental.xml.vm
@@ -44,49 +44,6 @@
       via the "MAVEN_OPTS" environment variable.
     </section>
 
-    <section name="Zinc Server">
-      <p>
-        Zinc supports much faster compilation by running as a server, keeping the
-        JVM and classloaders warm, and the Scala Maven Plugin can be used as a
-        Zinc client, connecting to a currently running Zinc server. This can
-        improve compilation speeds by a factor of two, or even more, giving the
-        same benefits as using sbt's interactive shell.
-      </p>
-      <p>
-        To use Zinc as a server, first install a local version of Zinc via the
-        <a href="https://github.com/typesafehub/zinc">Zinc homepage</a>.
-        You can start the Zinc server with:
-      </p>
-      <source>zinc -start</source>
-      <p>
-        Configure your project to use the Zinc server with the "useZincServer"
-        configuration option:
-      </p>
-      <source>
-        <![CDATA[
-<project>
-  ...
-  <plugin>
-    <groupId>${project.groupId}</groupId>
-    <artifactId>${project.artifactId}</artifactId>
-    <version>${project.version}</version>
-    <configuration>
-      <recompileMode>incremental</recompileMode>
-      <useZincServer>true</useZincServer>
-    </configuration>
-  </plugin>
-  ...
-</project>
-        ]]>
-      </source>
-      <p>
-        If there is no Zinc server currently running then the plugin falls back
-        to regular incremental compilation. To configure which port to connect
-        to, if Zinc is running on a non-default port, use the "zincPort"
-        configuration option.
-      </p>
-    </section>
-
     <section name="Mixed Scala and Java Sources">
       <p>
         The incremental compiler will compile both Scala and Java sources, rather

--- a/src/site/xdoc/faq.xml.vm
+++ b/src/site/xdoc/faq.xml.vm
@@ -12,7 +12,7 @@
     <section name="Incremental Compilation (w/ Zinc)">
       <dl>
 				<dt>Why does the maven plugin compile both Java and Scala sources</dt>
-        <dd>The <a href="https://github.com/typesafehub/zinc">Zinc incremental compilation</a> library needs access to both Java and Scala sources to accurately determine recompilation.            
+        <dd>The <a href="https://github.com/sbt/zinc">Zinc incremental compilation</a> library needs access to both Java and Scala sources to accurately determine recompilation.
 				</dd>
 			</dl>
 			<dl>


### PR DESCRIPTION
- Update references to Zinc to point to the currently maintained sbt Zinc project.
- Remove documentation on using Zinc server, as support for this was removed from the plugin in version 4.0.0

There are some other issues with the Incremental Compile documentation, such as incremental being enabled by default now in version 4.0.0. But I'm not familiar enough with this project to update that documentation any further.