### PR TITLE
Update zinc related description

### DIFF
--- a/src/site/xdoc/example_incremental.xml.vm
+++ b/src/site/xdoc/example_incremental.xml.vm
@@ -9,14 +9,16 @@
     <p>
       Incremental compilation is supported using
       <a href="https://github.com/sbt/zinc">Zinc</a>,
-      a stand-alone version of sbt's incremental compiler.
+      sbt's embedded incremental compiler.
     </p>
 
     <section name="Setup">
       <p>
-        To enable incremental compilation set the "recompileMode" configuration
-        option to "incremental".
-        For example:
+        The incremental compilation is enabled by default after
+        scala-maven-plugin v4.0.0, and the "recompileMode" configuration
+        option is set to "incremental" by default. You can also configure
+        the `recompileMode` configuration to `all` to disable the
+        incremental comiler. For example:
       </p>
       <source>
         <![CDATA[


### PR DESCRIPTION
Since scala-maven-plugin v4.0.0 [2], the incremental compilation is enabled by default [2] and remove the support of zinc stand-alone version (aka [typesafe/zinc](https://github.com/typesafehub/zinc)) [3].

This patch updates Zinc and `reompileMode` related decription.

Related: 
[1] https://github.com/davidB/scala-maven-plugin/pull/408
[2] https://github.com/davidB/scala-maven-plugin/commit/0f01f2fe37aaadbefb02fb713d469dbd10acf8b1
[3] https://github.com/davidB/scala-maven-plugin/pull/321
