### PR TITLE
Add Sbt-Delegate-Maven-Plugin to Similar Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The **scala-maven-plugin** (previously maven-scala-plugin) is used for compiling
 
 * [scalor-maven-plugin](https://github.com/random-maven/scalor-maven-plugin)
 * [sbt-compiler-maven-plugin](https://github.com/sbt-compiler-maven-plugin/sbt-compiler-maven-plugin)
+* [sbt-delegate-maven-plugin](https://github.com/AugustNagro/sbt-delegate-maven-plugin)
 
 ## Build
 


### PR DESCRIPTION
Hi!

As discussed in #486, I've make a maven plugin that simply delegates to SBT. There are some pros and cons with this approach, but it seems like the best way to use Scala.js and other advanced SBT features with maven.

https://github.com/AugustNagro/sbt-delegate-maven-plugin

Cheers,

August