### PR TITLE
Zinc exclusions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,6 +212,68 @@
       <groupId>org.scala-sbt</groupId>
       <artifactId>zinc_2.13</artifactId>
       <version>1.5.8</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jline</groupId>
+          <artifactId>jline</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.scala-sbt.jline3</groupId>
+          <artifactId>jline-terminal</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jline</groupId>
+          <artifactId>jline-terminal-jna</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jline</groupId>
+          <artifactId>jline-terminal-jansi</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.scala-sbt.jline</groupId>
+          <artifactId>jline</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.scala-lang.modules</groupId>
+          <artifactId>scala-xml_2.13</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.scala-sbt</groupId>
+          <artifactId>launcher-interface</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.scala-sbt</groupId>
+          <artifactId>sbinary_2.13</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.scala-sbt</groupId>
+          <artifactId>zinc-ivy-integration_2.13</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.eed3si9n</groupId>
+          <artifactId>sjson-new-core_2.13</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.eed3si9n</groupId>
+          <artifactId>sjson-new-scalajson_2.13</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.lihaoyi</groupId>
+          <artifactId>fastparse_2.13</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.lmax</groupId>
+          <artifactId>disruptor</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- provided -->

--- a/pom.xml
+++ b/pom.xml
@@ -142,9 +142,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-compat</artifactId>
-      <version>${maven.version}</version>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-dependency-tree</artifactId>
+      <version>3.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.reporting</groupId>
@@ -153,13 +153,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-core</artifactId>
-      <version>${maven.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.shared</groupId>
-      <artifactId>maven-dependency-tree</artifactId>
-      <version>3.1.0</version>
+      <artifactId>maven-archiver</artifactId>
+      <version>3.5.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -181,32 +176,7 @@
       <artifactId>plexus-classworlds</artifactId>
       <version>2.6.0</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-project</artifactId>
-      <version>2.2.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-archiver</artifactId>
-      <version>3.5.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.doxia</groupId>
-      <artifactId>doxia-sink-api</artifactId>
-      <version>1.11.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-model</artifactId>
-      <version>${maven.version}</version>
-    </dependency>
-    <!-- for scala:cctest -->
-    <dependency>
-      <groupId>org.apache.maven.shared</groupId>
-      <artifactId>maven-invoker</artifactId>
-      <version>3.1.0</version>
-    </dependency>
+
     <!-- sbt incremental compiler -->
     <dependency>
       <groupId>org.scala-sbt</groupId>
@@ -277,6 +247,43 @@
     </dependency>
 
     <!-- provided -->
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>${maven.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-compat</artifactId>
+      <version>${maven.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-project</artifactId>
+      <version>2.2.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.doxia</groupId>
+      <artifactId>doxia-sink-api</artifactId>
+      <version>1.11.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-model</artifactId>
+      <version>${maven.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <!-- for scala:cctest -->
+    <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-invoker</artifactId>
+      <version>3.1.0</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>


### PR DESCRIPTION
In particular, exclude log4j 2 we don't use, so that it's not even in the classpath.