### PR TITLE
Add maven.main.skip support

### DIFF
--- a/src/it/test_skip_main/invoker.properties
+++ b/src/it/test_skip_main/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean test-compile -e -Dmaven.main.skip=true

--- a/src/it/test_skip_main/pom.xml
+++ b/src/it/test_skip_main/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>it.scala-maven-plugin</groupId>
+    <artifactId>test_skip_test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Test for skipping compilation of test sources</name>
+    <description>Test for skipping compilation of test sources</description>
+    <packaging>pom</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>${scala.version.lastrelease}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>scala-compile-first</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>scala-test-compile</id>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/it/test_skip_main/src/main/scala/Main.scala
+++ b/src/it/test_skip_main/src/main/scala/Main.scala
@@ -1,0 +1,1 @@
+class Main

--- a/src/it/test_skip_main/src/test/scala/Test.scala
+++ b/src/it/test_skip_main/src/test/scala/Test.scala
@@ -1,0 +1,1 @@
+class Test

--- a/src/it/test_skip_main/validate.groovy
+++ b/src/it/test_skip_main/validate.groovy
@@ -1,0 +1,14 @@
+try {
+
+def mainFile = new File(basedir, 'target/classes/Main.class')
+assert !mainFile.exists()
+
+def testFile = new File(basedir, 'target/test-classes/Test.class')
+assert testFile.exists()
+
+return true
+
+} catch(Throwable e) {
+  e.printStackTrace()
+  return false
+}

--- a/src/it/test_skip_test/invoker.properties
+++ b/src/it/test_skip_test/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean test-compile -e -Dmaven.test.skip=true

--- a/src/it/test_skip_test/pom.xml
+++ b/src/it/test_skip_test/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>it.scala-maven-plugin</groupId>
+    <artifactId>test_skip_test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Test for skipping compilation of test sources</name>
+    <description>Test for skipping compilation of test sources</description>
+    <packaging>pom</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>${scala.version.lastrelease}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>scala-compile-first</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>scala-test-compile</id>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/it/test_skip_test/src/main/scala/Main.scala
+++ b/src/it/test_skip_test/src/main/scala/Main.scala
@@ -1,0 +1,1 @@
+class Main

--- a/src/it/test_skip_test/src/test/scala/Test.scala
+++ b/src/it/test_skip_test/src/test/scala/Test.scala
@@ -1,0 +1,1 @@
+class Test

--- a/src/it/test_skip_test/validate.groovy
+++ b/src/it/test_skip_test/validate.groovy
@@ -1,0 +1,14 @@
+try {
+
+def mainFile = new File(basedir, 'target/classes/Main.class')
+assert mainFile.exists()
+
+def testFile = new File(basedir, 'target/test-classes/Test.class')
+assert !testFile.exists()
+
+return true
+
+} catch(Throwable e) {
+  e.printStackTrace()
+  return false
+}

--- a/src/main/java/scala_maven/ScalaCompileMojo.java
+++ b/src/main/java/scala_maven/ScalaCompileMojo.java
@@ -9,6 +9,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import org.apache.maven.model.Dependency;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -25,6 +27,13 @@ import util.FileUtils;
     requiresDependencyResolution = ResolutionScope.COMPILE,
     threadSafe = true)
 public class ScalaCompileMojo extends ScalaCompilerSupport {
+
+  /**
+   * Set this to 'true' to bypass compilation of main sources. Its use is NOT RECOMMENDED, but quite
+   * convenient on occasion.
+   */
+  @Parameter(property = "maven.main.skip")
+  private boolean skipMain;
 
   /** The directory in which to place compilation output */
   @Parameter(property = "outputDir", defaultValue = "${project.build.outputDirectory}")
@@ -88,5 +97,14 @@ public class ScalaCompileMojo extends ScalaCompilerSupport {
   @Override
   protected File getAnalysisCacheFile() {
     return analysisCacheFile.getAbsoluteFile();
+  }
+
+  @Override
+  public void execute() throws MojoExecutionException, MojoFailureException {
+    if (skipMain) {
+      getLog().info("Not compiling main sources");
+      return;
+    }
+    super.execute();
   }
 }

--- a/src/main/java/scala_maven/ScalaTestCompileMojo.java
+++ b/src/main/java/scala_maven/ScalaTestCompileMojo.java
@@ -45,6 +45,7 @@ public class ScalaTestCompileMojo extends ScalaCompilerSupport {
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
     if (skip) {
+      getLog().info("Not compiling test sources");
       return;
     }
     super.execute();


### PR DESCRIPTION
Fixes #198. The new parameter mirrors [`skipMain`](https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#skipMain) in the Java compiler plugin.