### PR TITLE
Refactoring: dont remove and re-add output dirs from classpath

### DIFF
--- a/src/main/java/sbt_inc/SbtIncrementalCompiler.java
+++ b/src/main/java/sbt_inc/SbtIncrementalCompiler.java
@@ -152,13 +152,10 @@ public class SbtIncrementalCompiler {
       Path classesDirectory,
       List<String> scalacOptions,
       List<String> javacOptions) {
-    List<Path> fullClasspath = new ArrayList<>();
-    fullClasspath.add(classesDirectory);
-    fullClasspath.addAll(classpathElements);
 
     CompileOptions options =
         CompileOptions.of(
-            fullClasspath.stream()
+            classpathElements.stream()
                 .map(PlainVirtualFile::new)
                 .toArray(VirtualFile[]::new), // classpath
             sources.stream().map(PlainVirtualFile::new).toArray(VirtualFile[]::new), // sources

--- a/src/main/java/scala_maven/ScalaCompileMojo.java
+++ b/src/main/java/scala_maven/ScalaCompileMojo.java
@@ -71,7 +71,6 @@ public class ScalaCompileMojo extends ScalaCompilerSupport {
   @Override
   protected Set<File> getClasspathElements() throws Exception {
     final Set<File> back = FileUtils.fromStrings(project.getCompileClasspathElements());
-    back.remove(new File(project.getBuild().getOutputDirectory()));
     addAdditionalDependencies(back);
     if (classpath != null && classpath.getAdd() != null) {
       getLog().warn("using 'classpath' is deprecated, use 'additionalDependencies' instead");

--- a/src/main/java/scala_maven/ScalaCompilerSupport.java
+++ b/src/main/java/scala_maven/ScalaCompilerSupport.java
@@ -357,7 +357,6 @@ public abstract class ScalaCompilerSupport extends ScalaSourceMojoSupport {
               instance);
     }
 
-    classpathElements.remove(outputDir);
     List<String> scalacOptions = getScalaOptions();
     List<String> javacOptions = getJavacOptions();
 

--- a/src/main/java/scala_maven/ScalaTestCompileMojo.java
+++ b/src/main/java/scala_maven/ScalaTestCompileMojo.java
@@ -60,7 +60,6 @@ public class ScalaTestCompileMojo extends ScalaCompilerSupport {
   @Override
   protected Set<File> getClasspathElements() throws Exception {
     Set<File> back = FileUtils.fromStrings(project.getTestClasspathElements());
-    back.remove(new File(project.getBuild().getTestOutputDirectory()));
     addAdditionalDependencies(back);
     return back;
   }


### PR DESCRIPTION
We need output dirs in the classpath for mixed compilation.
Stop removing them while we're actually adding them back later in SbtIncrementalCompiler