### PR TITLE
Fix incremental compiler not being able to find JDK classes when compiler macros with Java 11, close #502

### DIFF
--- a/src/main/java/scala_maven/ScalaCompilerLoader.java
+++ b/src/main/java/scala_maven/ScalaCompilerLoader.java
@@ -16,6 +16,8 @@
 
 package scala_maven;
 
+import sbt.internal.inc.classpath.ClasspathUtil;
+
 import java.net.URL;
 import java.net.URLClassLoader;
 
@@ -25,7 +27,7 @@ public class ScalaCompilerLoader extends URLClassLoader {
   private final ClassLoader sbtLoader;
 
   public ScalaCompilerLoader(URL[] urls, ClassLoader sbtLoader) {
-    super(urls, null);
+    super(urls, ClasspathUtil.rootLoader());
     this.sbtLoader = sbtLoader;
   }
 

--- a/src/main/java/scala_maven/ScalaCompilerSupport.java
+++ b/src/main/java/scala_maven/ScalaCompilerSupport.java
@@ -302,10 +302,9 @@ public abstract class ScalaCompilerSupport extends ScalaSourceMojoSupport {
     allJars.addAll(Arrays.asList(libraryJars));
     File[] allJarFiles = allJars.toArray(new File[] {});
 
-    URLClassLoader loaderLibraryOnly =
+    ClassLoader loaderLibraryOnly =
         new ScalaCompilerLoader(libraryJarUrls, xsbti.Reporter.class.getClassLoader());
-    URLClassLoader loaderCompilerOnly = new URLClassLoader(compilerJarUrls, loaderLibraryOnly);
-    URLClassLoader loader = loaderCompilerOnly;
+    ClassLoader loaderCompilerOnly = new URLClassLoader(compilerJarUrls, loaderLibraryOnly);
 
     if (getLog().isDebugEnabled()) {
       getLog().debug("compilerJars: " + FileUtils.toMultiPath(compilerJars));
@@ -314,7 +313,7 @@ public abstract class ScalaCompilerSupport extends ScalaSourceMojoSupport {
 
     return new ScalaInstance(
         sc.version().toString(),
-        loader,
+        loaderCompilerOnly,
         loaderCompilerOnly,
         loaderLibraryOnly,
         libraryJars,


### PR DESCRIPTION
Motivation:

Jigsaw has changed the behavior of ClassLoaders.
For some reason, ScalaCompilerLoader with a null parent is able to find JDK classes on Java 8 but not on Java 11.

Modification:

Make the parent the root loader.

Result:

We can compile macros with Java 11.