### PR TITLE
Fix incremental compilation on Java 11+, close #600

### DIFF
--- a/src/main/java/sbt_inc/SbtIncrementalCompiler.java
+++ b/src/main/java/sbt_inc/SbtIncrementalCompiler.java
@@ -169,7 +169,7 @@ public class SbtIncrementalCompiler {
             pos -> pos, // sourcePositionMappers
             compileOrder, // order
             Optional.empty(), // temporaryClassesDirectory
-            Optional.of(PlainVirtualFileConverter.converter()), // _converter
+            Optional.empty(), // _converter
             Optional.empty(), // _stamper
             Optional.empty() // _earlyOutput
             );


### PR DESCRIPTION
Remove the FileConverter, it seems to break things.