### PR TITLE
Fix JavaLocator, close #619

### DIFF
--- a/src/main/java/util/JavaLocator.java
+++ b/src/main/java/util/JavaLocator.java
@@ -5,6 +5,9 @@
 package util;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.Locale;
+
 import org.apache.maven.toolchain.Toolchain;
 
 /**
@@ -14,29 +17,57 @@ import org.apache.maven.toolchain.Toolchain;
  */
 public class JavaLocator {
 
-  public static String findExecutableFromToolchain(Toolchain toolchain) {
-    String javaExec = null;
+  private static final boolean IS_WINDOWS =
+    System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
+
+  // inspired from org.codehaus.plexus.compiler.javac.JavacCompiler#getJavacExecutable
+  public static String findExecutableFromToolchain(Toolchain toolchain) throws IOException {
 
     if (toolchain != null) {
-      javaExec = toolchain.findTool("java");
+      String fromToolChain = toolchain.findTool("java");
+      if (fromToolChain != null) {
+        return fromToolChain;
+      }
     }
 
-    if (javaExec == null) {
-      String javaHome = System.getenv("JAVA_HOME");
-      if (javaHome == null) {
-        javaHome = System.getProperty("java.home"); // fallback to JRE
+    String javaCommand = "java" + (IS_WINDOWS ? ".exe" : "");
+
+    String javaHomeSystemProperty = System.getProperty("java.home");
+    if (javaHomeSystemProperty != null) {
+      if (javaHomeSystemProperty.endsWith(File.separator + "jre")) {
+        // Old JDK versions contain a JRE. We might be pointing to that.
+        // We want to try to use the JDK instead as we need javac in order to compile mixed Java-Scala projects.
+        File javaExecFile = new File(javaHomeSystemProperty + File.separator + ".." + File.separator + "bin", javaCommand);
+        if (javaExecFile.isFile()) {
+          // getCanonicalPath to get rid of ".."
+          return javaExecFile.getCanonicalPath();
+        }
       }
-      if (javaHome == null) {
-        throw new IllegalStateException(
-            "Couldn't locate java, try setting JAVA_HOME environment variable.");
+
+      // old standalone JRE or modern JDK
+      File javaExecFile = new File(javaHomeSystemProperty + File.separator + "bin", javaCommand);
+      if (javaExecFile.isFile()) {
+        return javaExecFile.getAbsolutePath();
+      } else {
+        throw new IllegalStateException("Couldn't locate java in defined java.home system property.");
       }
-      javaExec = javaHome + File.separator + "bin" + File.separator + "java";
     }
 
-    return javaExec;
+    // fallback: try to resolve from JAVA_HOME
+    String javaHomeEnvVar = System.getenv("JAVA_HOME");
+    if (javaHomeEnvVar == null) {
+      throw new IllegalStateException("Couldn't locate java, try setting JAVA_HOME environment variable.");
+    }
+
+    File javaExecFile = new File(javaHomeEnvVar + File.separator + "bin", javaCommand);
+    if (javaExecFile.isFile()) {
+      return javaExecFile.getAbsolutePath();
+    } else {
+      throw new IllegalStateException("Couldn't locate java in defined JAVA_HOME environment variable.");
+    }
   }
 
-  public static File findHomeFromToolchain(Toolchain toolchain) {
+  public static File findHomeFromToolchain(Toolchain toolchain) throws IOException {
     String executable = findExecutableFromToolchain(toolchain);
     File executableParent = new File(executable).getParentFile();
     if (executableParent == null) {


### PR DESCRIPTION
Motivation:

1. We should prefer the Java installation used to run maven to what's defined in JAVA_HOME
2. We should prefer JDK over JRE (for old versions that used to have one) as we need javac for compiling Java code in mixed projects

Modifications:

Resolve with the following chain:
* prefer toolchain if defined
* try to use "java.home" System prop to resolve a JDK, a JRE otherwise
* fall back to JAVA_HOME env var

Result:

Behavior consistent with `maven-compiler-plugin` and `org.codehaus.plexus.compiler.javac.JavacCompiler#getJavacExecutable`.

In particular:
* we no longer unexpectedly jump to a different Java install because JAVA_HOME env var is defined
* we no longer crash on Java 8 when trying to compile mixed projects and JAVA_HOME env var is undefined or doesn't point to a JDK.