### PR TITLE
Set skip's user property to maven.scaladoc.skip

### DIFF
--- a/src/main/java/scala_maven/ScalaDocJarMojo.java
+++ b/src/main/java/scala_maven/ScalaDocJarMojo.java
@@ -57,7 +57,7 @@ public class ScalaDocJarMojo extends ScalaDocMojo {
   private String classifier;
 
   /** Specifies whether to skip generating scaladoc. */
-  @Parameter(property = "skip", defaultValue = "false")
+  @Parameter(property = "maven.scaladoc.skip", defaultValue = "false")
   private boolean skip;
 
   /** Specifies the directory where the generated jar file will be put. */


### PR DESCRIPTION
`-Dskip=true` also skips building the test jar. This PR makes the user property to `maven.scaladoc.skip`.

At least two projects use this property:
https://issues.apache.org/jira/browse/SPARK-43461
https://github.com/apache/kyuubi/blob/1e310a0818f23dd7b8f2d4afd17795794fed46ea/pom.xml#L238