### PR TITLE
Improve performance of multimodule build by reusing compiler objects

### DIFF
--- a/src/main/java/sbt_inc/ForkedSbtIncrementalCompilerMain.java
+++ b/src/main/java/sbt_inc/ForkedSbtIncrementalCompilerMain.java
@@ -8,7 +8,6 @@ import java.io.*;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
-import sbt.internal.inc.ScalaInstance;
 import sbt.util.Level;
 import sbt.util.Logger;
 import scala.Enumeration;
@@ -165,26 +164,22 @@ public final class ForkedSbtIncrementalCompilerMain {
           public void trace(Function0<Throwable> t) {}
         };
 
-    ScalaInstance scalaInstance =
-        ScalaInstances.makeScalaInstance(
-            parsedArgs.scalaVersion,
-            parsedArgs.compilerAndDependencies,
-            parsedArgs.libraryAndDependencies);
-
     SbtIncrementalCompiler incrementalCompiler =
         SbtIncrementalCompilers.makeInProcess(
             parsedArgs.javaHome,
-            parsedArgs.cacheFile,
-            parsedArgs.compileOrder,
-            scalaInstance,
             parsedArgs.compilerBridgeJar,
-            sbtLogger);
+            sbtLogger,
+            parsedArgs.scalaVersion,
+            parsedArgs.compilerAndDependencies,
+            parsedArgs.libraryAndDependencies);
 
     incrementalCompiler.compile(
         parsedArgs.classpathElements,
         parsedArgs.sources,
         parsedArgs.classesDirectory,
         parsedArgs.scalacOptions,
-        parsedArgs.javacOptions);
+        parsedArgs.javacOptions,
+        parsedArgs.compileOrder,
+        parsedArgs.cacheFile);
   }
 }

--- a/src/main/java/sbt_inc/SbtIncrementalCompiler.java
+++ b/src/main/java/sbt_inc/SbtIncrementalCompiler.java
@@ -6,6 +6,7 @@ package sbt_inc;
 
 import java.io.File;
 import java.util.Collection;
+import xsbti.compile.CompileOrder;
 
 public interface SbtIncrementalCompiler {
 
@@ -14,5 +15,7 @@ public interface SbtIncrementalCompiler {
       Collection<File> sources,
       File classesDirectory,
       Collection<String> scalacOptions,
-      Collection<String> javacOptions);
+      Collection<String> javacOptions,
+      CompileOrder compileOrder,
+      File cacheFile);
 }

--- a/src/main/java/scala_maven/ScalaCompilerSupport.java
+++ b/src/main/java/scala_maven/ScalaCompilerSupport.java
@@ -307,8 +307,6 @@ public abstract class ScalaCompilerSupport extends ScalaSourceMojoSupport {
               new MavenArtifactResolver(factory, session),
               secondaryCacheDir,
               getLog(),
-              cacheFile,
-              compileOrder,
               sc.version(),
               sc.findCompilerAndDependencies().stream()
                   .map(Artifact::getFile)
@@ -323,7 +321,13 @@ public abstract class ScalaCompilerSupport extends ScalaSourceMojoSupport {
 
     try {
       incremental.compile(
-          classpathElements, sources, outputDir, getScalacOptions(), getJavacOptions());
+          classpathElements,
+          sources,
+          outputDir,
+          getScalacOptions(),
+          getJavacOptions(),
+          compileOrder,
+          cacheFile);
     } catch (xsbti.CompileFailed e) {
       if (compileInLoop) {
         compileErrors = true;


### PR DESCRIPTION
Hi,

We're using the scala-maven-plugin for one of our projects having multiple maven modules with scala code.
We observed, that each invocation of scala:compile hangs the build for several seconds.
After some digging into the plugin code I found out, that it does cold start of the compiler infrastructure each time it is invoked.
I managed to rearrange some code to make it possible to share the compiler bridge jar and compiler objects via static fields.
This simple change reduces `mvn clean install` (without tests) execution time by ~50%.