### PR TITLE
Remove deprecated dependency on maven-compat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,12 +259,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-compat</artifactId>
-      <version>${maven.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>2.2.1</version>
       <scope>provided</scope>


### PR DESCRIPTION
Maven 4 will no longer include the `org.apache.maven:maven-compat` library in the runtime.

Current versions of Maven 3 produce deprecation warnings related to this dependency in the plugin.

This PR removes the library as it does not appear to be used.