### PR TITLE
Replace system-rules with system-stubs-junit4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,9 +296,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.stefanbirkner</groupId>
-      <artifactId>system-rules</artifactId>
-      <version>1.19.0</version>
+      <groupId>uk.org.webcompere</groupId>
+      <artifactId>system-stubs-junit4</artifactId>
+      <version>2.1.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -469,10 +469,10 @@
           <doclint>-missing</doclint>
           <links>
             <!--link>http://java.sun.com/j2se/${maven.compiler.source}/docs/api/</link-->
-            <link>http://slf4j.org/api/</link>
-            <link>http://commons.apache.org/lang/api-release/</link>
-            <link>http://commons.apache.org/io/api-release/</link>
-            <link>http://junit.sourceforge.net/javadoc/</link>
+            <link>https://slf4j.org/api/</link>
+            <link>https://commons.apache.org/proper/commons-lang/javadocs/api-release/</link>
+            <link>https://commons.apache.org/proper/commons-io/javadocs/api-release/</link>
+            <link>https://junit.org/junit4/javadoc/latest/</link>
           </links>
           <!-- additionalparam>-nopackagediagram</additionalparam-->
           <!-- additionalparam>-sourceclasspath ${project.build.outputDirectory}</additionalparam-->

--- a/src/test/java/util/JavaLocatorTest.java
+++ b/src/test/java/util/JavaLocatorTest.java
@@ -10,11 +10,11 @@ import java.io.File;
 import org.apache.maven.toolchain.Toolchain;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.rules.EnvironmentVariablesRule;
 
 public class JavaLocatorTest {
 
-  @Rule public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+  @Rule public final EnvironmentVariablesRule environmentVariables = new EnvironmentVariablesRule();
 
   @Test
   public void shouldReturnNotNullWhenJavaIsNotAvailableOnCommandLineAndJavaHomeIsPresent() {


### PR DESCRIPTION
system-rules no longer works with Java 17.
system-stubs-junit4 is a fork that works with all JDK versions.

https://www.baeldung.com/java-unit-testing-environment-variables