### PR TITLE
Manipulating classpath items should preserve item order

### DIFF
--- a/src/main/java/util/FileUtils.java
+++ b/src/main/java/util/FileUtils.java
@@ -36,7 +36,9 @@ public class FileUtils {
   }
 
   public static Set<File> fromStrings(Collection<String> s) {
-    return s.stream().map(File::new).collect(Collectors.toSet());
+    return s.stream().map(File::new).collect(
+      Collectors.toCollection(LinkedHashSet::new)
+    );
   }
 
   public static String toMultiPath(Collection<File> paths) {

--- a/src/test/java/util/FileUtilsTest.java
+++ b/src/test/java/util/FileUtilsTest.java
@@ -1,0 +1,28 @@
+/*
+ * This is free and unencumbered software released into the public domain.
+ * See UNLICENSE.
+ */
+package util;
+
+import com.google.common.collect.Lists;
+import junit.framework.TestCase;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class FileUtilsTest {
+  @Test
+  public void fromStrings_should_preserve_insertion_order(){
+    List<String> expected = Lists.newArrayList("5.jar", "23.jar", "56.jar", "2.jar", "48.jar", "99.jar", "1234.jar");
+    Set<File> files = FileUtils.fromStrings(expected);
+    List<String> actual = Lists.newArrayList();
+    for (File file : files) {
+        actual.add(file.getName());
+    }
+    assertEquals(actual, expected);
+  }
+}


### PR DESCRIPTION
`ScalaCompileMojo#getClasspathElements` and `ScalaTestCompileMojo#getClasspathElements` compute the compilation and test compilation classpath from `MavenProject#getCompileClasspathElements` which is a `List<String>`.

Transforming from the ordered `List<String>` into an unordered `Hashset<File>` can change the order of classpath elements.

In my specific case, it broke the [develocity cache key computation](https://develocity.apache.org/c/unuozmm6ecqpc/nusnauq3l6a6u/goal-inputs?expanded=WyJuemRibm96bGFrZ2FnLWNsYXNzcGF0aGVsZW1lbnRzIiwibnpkYm5vemxha2dhZy1jbGFzc3BhdGhFbGVtZW50cy0wLWZpbGUtb3JkZXIiXQ) I'm using to improve Apache James build times.
In other cases it could lead to incorrect compilation or compilation errors ..
