### PR TITLE
Add unit tests for JavaLocator

### DIFF
--- a/src/test/java/util/JavaLocatorTest.java
+++ b/src/test/java/util/JavaLocatorTest.java
@@ -7,14 +7,37 @@ package util;
 import static org.junit.Assert.*;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.apache.maven.toolchain.Toolchain;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import uk.org.webcompere.systemstubs.rules.EnvironmentVariablesRule;
 
 public class JavaLocatorTest {
 
+  @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
   @Rule public final EnvironmentVariablesRule environmentVariables = new EnvironmentVariablesRule();
+
+  private String originalJavaHome;
+
+  @Before
+  public void saveJavaHome() {
+    originalJavaHome = System.getProperty("java.home");
+  }
+
+  @After
+  public void restoreJavaHome() {
+    if (originalJavaHome != null) {
+      System.setProperty("java.home", originalJavaHome);
+    } else {
+      System.clearProperty("java.home");
+    }
+  }
 
   @Test
   public void shouldReturnNotNullWhenJavaIsNotAvailableOnCommandLineAndJavaHomeIsPresent() {
@@ -53,6 +76,152 @@ public class JavaLocatorTest {
   public void shouldReturnNullWhenFileIsNotPresent() {
     File home = JavaLocator.findHomeFromToolchain(new ReturningToolChain("my-path-to-java"));
     assertNull(home);
+  }
+
+  @Test
+  public void shouldFindJavaFromJavaHomeWhenToolchainIsNull() throws IOException {
+    // Create a fake JDK structure under temp folder
+    Path javaHome = tempFolder.newFolder("fakejdk").toPath();
+    Path javaExec = javaHome.resolve("bin").resolve("java");
+    Files.createDirectories(javaExec.getParent());
+    Files.createFile(javaExec);
+
+    System.setProperty("java.home", javaHome.toString());
+    environmentVariables.set("JAVA_HOME", null);
+
+    File result = JavaLocator.findExecutableFromToolchain(null);
+    assertNotNull(result);
+    assertEquals(javaExec.toString(), result.getAbsolutePath());
+  }
+
+  @Test
+  public void shouldFindJavaInJreSiblingBinWhenJavaHomeEndsWithJre() throws IOException {
+    // Create structure: fakejdk/jre (java.home) and fakejdk/bin/java (sibling)
+    Path jdkRoot = tempFolder.newFolder("fakejdk").toPath();
+    Path jreDir = jdkRoot.resolve("jre");
+    Files.createDirectories(jreDir);
+    Path javaExec = jdkRoot.resolve("bin").resolve("java");
+    Files.createDirectories(javaExec.getParent());
+    Files.createFile(javaExec);
+
+    System.setProperty("java.home", jreDir.toString());
+    environmentVariables.set("JAVA_HOME", null);
+
+    File result = JavaLocator.findExecutableFromToolchain(null);
+    assertNotNull(result);
+    assertEquals(javaExec.toString(), result.getAbsolutePath());
+  }
+
+  @Test
+  public void shouldFallBackToJreBinWhenSiblingBinDoesNotExist() throws IOException {
+    // Create structure: fakejdk/jre/bin/java (java.home ends with jre, but no sibling bin)
+    Path jdkRoot = tempFolder.newFolder("fakejdk").toPath();
+    Path jreDir = jdkRoot.resolve("jre");
+    Path javaExec = jreDir.resolve("bin").resolve("java");
+    Files.createDirectories(javaExec.getParent());
+    Files.createFile(javaExec);
+
+    System.setProperty("java.home", jreDir.toString());
+    environmentVariables.set("JAVA_HOME", null);
+
+    File result = JavaLocator.findExecutableFromToolchain(null);
+    assertNotNull(result);
+    assertEquals(javaExec.toString(), result.getAbsolutePath());
+  }
+
+  @Test
+  public void shouldThrowWhenJavaHomeDoesNotContainJava() throws IOException {
+    // Create a java.home without bin/java
+    Path javaHome = tempFolder.newFolder("fakejdk").toPath();
+    Files.createDirectories(javaHome.resolve("bin"));
+
+    System.setProperty("java.home", javaHome.toString());
+    environmentVariables.set("JAVA_HOME", null);
+
+    try {
+      JavaLocator.findExecutableFromToolchain(null);
+      fail("Expected IllegalStateException");
+    } catch (IllegalStateException e) {
+      assertEquals("Couldn't locate java in defined java.home system property.", e.getMessage());
+    }
+  }
+
+  @Test
+  public void shouldFindJavaFromJavaHomeEnvVar() throws IOException {
+    // Create a fake JDK structure under temp folder
+    Path javaHome = tempFolder.newFolder("fakejdk").toPath();
+    Path javaExec = javaHome.resolve("bin").resolve("java");
+    Files.createDirectories(javaExec.getParent());
+    Files.createFile(javaExec);
+
+    System.clearProperty("java.home");
+    environmentVariables.set("JAVA_HOME", javaHome.toString());
+
+    File result = JavaLocator.findExecutableFromToolchain(null);
+    assertNotNull(result);
+    assertEquals(javaExec.toString(), result.getAbsolutePath());
+  }
+
+  @Test
+  public void shouldThrowWhenJavaHomeEnvVarDoesNotContainJava() throws IOException {
+    // Create a JAVA_HOME without bin/java
+    Path javaHome = tempFolder.newFolder("fakejdk").toPath();
+    Files.createDirectories(javaHome.resolve("bin"));
+
+    System.clearProperty("java.home");
+    environmentVariables.set("JAVA_HOME", javaHome.toString());
+
+    try {
+      JavaLocator.findExecutableFromToolchain(null);
+      fail("Expected IllegalStateException");
+    } catch (IllegalStateException e) {
+      assertEquals(
+          "Couldn't locate java in defined JAVA_HOME environment variable.", e.getMessage());
+    }
+  }
+
+  @Test
+  public void shouldReturnCorrectPathFromJavaHomeProperty() throws IOException {
+    // Verify the returned path contains the expected java.home prefix
+    Path javaHome = tempFolder.newFolder("myjdk").toPath();
+    Path javaExec = javaHome.resolve("bin").resolve("java");
+    Files.createDirectories(javaExec.getParent());
+    Files.createFile(javaExec);
+
+    System.setProperty("java.home", javaHome.toString());
+    environmentVariables.set("JAVA_HOME", null);
+
+    File result = JavaLocator.findExecutableFromToolchain(null);
+    assertTrue(result.getAbsolutePath().startsWith(javaHome.toString()));
+    assertEquals("java", result.getName());
+  }
+
+  @Test
+  public void shouldNotEnterJreBranchWhenJavaHomeDoesNotEndWithJre() throws IOException {
+    // Create structure where a sibling "bin/java" exists but java.home doesn't end with "jre"
+    // If the endsWith("jre") check is always true (mutant), it would return the sibling path
+    // instead of the correct path inside java.home
+    Path parentDir = tempFolder.newFolder("parent").toPath();
+    Path javaHome = parentDir.resolve("myjdk");
+    Files.createDirectories(javaHome);
+
+    // Create the CORRECT java inside java.home/bin/java
+    Path correctJava = javaHome.resolve("bin").resolve("java");
+    Files.createDirectories(correctJava.getParent());
+    Files.createFile(correctJava);
+
+    // Create a DECOY java at sibling path: parent/bin/java (resolveSibling("bin") from myjdk)
+    Path decoyJava = parentDir.resolve("bin").resolve("java");
+    Files.createDirectories(decoyJava.getParent());
+    Files.createFile(decoyJava);
+
+    System.setProperty("java.home", javaHome.toString());
+    environmentVariables.set("JAVA_HOME", null);
+
+    File result = JavaLocator.findExecutableFromToolchain(null);
+    assertNotNull(result);
+    // Must return the java inside java.home, NOT the sibling decoy
+    assertEquals(correctJava.toString(), result.getAbsolutePath());
   }
 
   static final class ReturningToolChain implements Toolchain {


### PR DESCRIPTION
Adds unit tests for `util.JavaLocator`, which previously had little coverage of its executable-resolution logic.

The new tests cover `findExecutableFromToolchain(...)`:
- resolving `java` from the `java.home` system property
- resolving `java` from the `JAVA_HOME` environment variable
- the JDK-with-`jre` layout (sibling `bin/java`) and the fallback when no sibling `bin` exists
- both `IllegalStateException` paths (java.home / JAVA_HOME set but no `bin/java`), asserting the exact messages

They use `TemporaryFolder` for throwaway JDK layouts and save/restore `java.home` in `@Before`/`@After` so no global state leaks, and reuse the existing `environmentVariables` rule.

I found the gaps with PIT mutation testing; the additions take the class from 34 to 77 killed mutants. One test (`shouldNotEnterJreBranchWhenJavaHomeDoesNotEndWithJre`) specifically pins the `endsWith("jre")` branch, which nothing covered before.

Additive only: +8 tests, no production changes.


---

**How this was produced**

This PR was generated with an AI-assisted pipeline built around mutation testing (PIT). The pipeline mutates the target class (flipping conditions and changing boundary/edge cases) and runs the existing tests against each mutant. Where a mutant survives (the existing tests do not catch that edge case), it writes a focused test for that case and reruns PIT to confirm the new test actually kills that specific mutant. So every added test is verified to catch a concrete edge case the suite missed before, rather than being speculative or redundant. The change is additive only (no production code modified), and the module builds green under its CI JDK.
