### PR TITLE
Fix multi-module in-process builds with `recompileMode=all`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -686,6 +686,7 @@
                 <pomExclude>**/mi*/pom.xml</pomExclude>
                 <pomExclude>**/test_macroparadise/macro/pom.xml</pomExclude>
                 <pomExclude>**/test_macroparadise/core/pom.xml</pomExclude>
+                <pomExclude>**/test_inprocess_multimodule*/mod-*/pom.xml</pomExclude>
                 <pomExclude>scalac-plugin/src/it/**/pom.xml</pomExclude>
               </pomExcludes>
               <preBuildHookScript>setup.groovy</preBuildHookScript>

--- a/src/it/test_inprocess_multimodule/invoker.properties
+++ b/src/it/test_inprocess_multimodule/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean compile -DdisplayCmd=true -e

--- a/src/it/test_inprocess_multimodule/mod-a/pom.xml
+++ b/src/it/test_inprocess_multimodule/mod-a/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>it.scala-maven-plugin</groupId>
+    <artifactId>test_inprocess_multimodule</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>mod-a</artifactId>
+</project>

--- a/src/it/test_inprocess_multimodule/mod-a/src/main/scala/a/A.scala
+++ b/src/it/test_inprocess_multimodule/mod-a/src/main/scala/a/A.scala
@@ -1,0 +1,2 @@
+package a
+object A { def hello: String = "A" }

--- a/src/it/test_inprocess_multimodule/mod-b/pom.xml
+++ b/src/it/test_inprocess_multimodule/mod-b/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>it.scala-maven-plugin</groupId>
+    <artifactId>test_inprocess_multimodule</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>mod-b</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>it.scala-maven-plugin</groupId>
+      <artifactId>mod-a</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/test_inprocess_multimodule/mod-b/src/main/scala/b/B.scala
+++ b/src/it/test_inprocess_multimodule/mod-b/src/main/scala/b/B.scala
@@ -1,0 +1,3 @@
+package b
+import a.A
+object B { def go: String = A.hello + "B" }

--- a/src/it/test_inprocess_multimodule/pom.xml
+++ b/src/it/test_inprocess_multimodule/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>it.scala-maven-plugin</groupId>
+  <artifactId>test_inprocess_multimodule</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <name>${project.artifactId}</name>
+
+  <!-- Reactor with fork=false: module 'b' compiles only if the Maven JVM survived module 'a'.
+       Without the non-exiting process() entry point, the non-incremental (recompileMode=all)
+       compiler's main() calls System.exit after module 'a', killing the reactor, so 'b' is
+       never built. -->
+
+  <properties>
+    <scala.compat.version>2.13</scala.compat.version>
+    <scala.version>2.13.17</scala.version>
+  </properties>
+
+  <modules>
+    <module>mod-a</module>
+    <module>mod-b</module>
+  </modules>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>${scala.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <scalaVersion>${scala.version}</scalaVersion>
+          <scalaCompatVersion>${scala.compat.version}</scalaCompatVersion>
+          <fork>false</fork>
+          <recompileMode>all</recompileMode>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/test_inprocess_multimodule/validate.groovy
+++ b/src/it/test_inprocess_multimodule/validate.groovy
@@ -1,0 +1,9 @@
+try {
+  def modA = new File(basedir, 'mod-a/target/classes/a/A.class')
+  def modB = new File(basedir, 'mod-b/target/classes/b/B.class')
+  assert modA.exists() : "mod-a did not compile"
+  // The real assertion: the reactor reached and built the SECOND module. Without the non-exiting
+  // process() entry point, module 'a' System.exit()s the Maven JVM and 'b' is never compiled.
+  assert modB.exists() : "mod-b was NOT compiled — reactor did not survive module 'a' (in-process System.exit)"
+  return true
+} catch(Throwable e) { e.printStackTrace(); return false }

--- a/src/it/test_inprocess_multimodule_scala3/invoker.properties
+++ b/src/it/test_inprocess_multimodule_scala3/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean compile -DdisplayCmd=true -e

--- a/src/it/test_inprocess_multimodule_scala3/mod-a/pom.xml
+++ b/src/it/test_inprocess_multimodule_scala3/mod-a/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>it.scala-maven-plugin</groupId>
+    <artifactId>test_inprocess_multimodule_scala3</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>mod-a</artifactId>
+</project>

--- a/src/it/test_inprocess_multimodule_scala3/mod-a/src/main/scala/a/A.scala
+++ b/src/it/test_inprocess_multimodule_scala3/mod-a/src/main/scala/a/A.scala
@@ -1,0 +1,2 @@
+package a
+object A { def hello: String = "A" }

--- a/src/it/test_inprocess_multimodule_scala3/mod-b/pom.xml
+++ b/src/it/test_inprocess_multimodule_scala3/mod-b/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>it.scala-maven-plugin</groupId>
+    <artifactId>test_inprocess_multimodule_scala3</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>mod-b</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>it.scala-maven-plugin</groupId>
+      <artifactId>mod-a</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/test_inprocess_multimodule_scala3/mod-b/src/main/scala/b/B.scala
+++ b/src/it/test_inprocess_multimodule_scala3/mod-b/src/main/scala/b/B.scala
@@ -1,0 +1,3 @@
+package b
+import a.A
+object B { def go: String = A.hello + "B" }

--- a/src/it/test_inprocess_multimodule_scala3/pom.xml
+++ b/src/it/test_inprocess_multimodule_scala3/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>it.scala-maven-plugin</groupId>
+  <artifactId>test_inprocess_multimodule_scala3</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <name>${project.artifactId}</name>
+
+  <!-- Reactor with fork=false: module 'b' compiles only if the Maven JVM survived module 'a'.
+       Without the non-exiting process() entry point, the non-incremental (recompileMode=all)
+       compiler's main() calls System.exit after module 'a', killing the reactor, so 'b' is
+       never built. -->
+
+  <properties>
+    <scala.compat.version>3</scala.compat.version>
+    <scala.version>3.4.1</scala.version>
+  </properties>
+
+  <modules>
+    <module>mod-a</module>
+    <module>mod-b</module>
+  </modules>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala3-library_3</artifactId>
+      <version>${scala.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <scalaVersion>${scala.version}</scalaVersion>
+          <scalaCompatVersion>${scala.compat.version}</scalaCompatVersion>
+          <fork>false</fork>
+          <recompileMode>all</recompileMode>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/test_inprocess_multimodule_scala3/validate.groovy
+++ b/src/it/test_inprocess_multimodule_scala3/validate.groovy
@@ -1,0 +1,9 @@
+try {
+  def modA = new File(basedir, 'mod-a/target/classes/a/A.class')
+  def modB = new File(basedir, 'mod-b/target/classes/b/B.class')
+  assert modA.exists() : "mod-a did not compile"
+  // The real assertion: the reactor reached and built the SECOND module. Without the non-exiting
+  // process() entry point, module 'a' System.exit()s the Maven JVM and 'b' is never compiled.
+  assert modB.exists() : "mod-b was NOT compiled — reactor did not survive module 'a' (in-process System.exit)"
+  return true
+} catch(Throwable e) { e.printStackTrace(); return false }

--- a/src/main/java/scala_maven/ScalaCompilerSupport.java
+++ b/src/main/java/scala_maven/ScalaCompilerSupport.java
@@ -14,6 +14,7 @@ import sbt_inc.SbtIncrementalCompiler;
 import sbt_inc.SbtIncrementalCompilers;
 import scala_maven_dependency.Context;
 import scala_maven_executions.JavaMainCaller;
+import scala_maven_executions.JavaMainCallerInProcess.EntryPoint;
 import util.FileUtils;
 import util.JavaLocator;
 import xsbti.compile.CompileOrder;
@@ -103,6 +104,15 @@ public abstract class ScalaCompilerSupport extends ScalaSourceMojoSupport {
   protected JavaMainCaller getScalaCommand() throws Exception {
     Context sc = findScalaContext();
     return getScalaCommand(fork, sc.compilerMainClassName(scalaClassName, false));
+  }
+
+  /**
+   * Compilation uses the compiler's non-exiting {@link EntryPoint#PROCESS} entry point so that an
+   * in-process reactor build is not killed by the {@code System.exit} that {@code main} would call.
+   */
+  @Override
+  protected EntryPoint inProcessEntryPoint() {
+    return EntryPoint.PROCESS;
   }
 
   protected int compile(

--- a/src/main/java/scala_maven/ScalaMojoSupport.java
+++ b/src/main/java/scala_maven/ScalaMojoSupport.java
@@ -177,6 +177,13 @@ public abstract class ScalaMojoSupport extends AbstractMojo {
   @Parameter(defaultValue = "true")
   protected boolean fork = true;
 
+  /**
+   * When compiling in-process ({@code fork=false}), reuse the loaded Scala compiler across modules
+   * to keep it JIT-warm instead of loading a fresh one per module.
+   */
+  @Parameter(property = "reuseInProcessCompiler", defaultValue = "true")
+  protected boolean reuseInProcessCompiler = true;
+
   /** Force the use of an external ArgFile to run any forked process. */
   @Parameter(defaultValue = "false")
   protected boolean forceUseArgFile = false;
@@ -579,7 +586,14 @@ public abstract class ScalaMojoSupport extends AbstractMojo {
     } else {
       cmd =
           new JavaMainCallerInProcess(
-              getLog(), mainClass, toolcp, null, null, inProcessEntryPoint());
+              getLog(),
+              mainClass,
+              toolcp,
+              null,
+              null,
+              inProcessEntryPoint(),
+              reuseInProcessCompiler,
+              findScalaContext().compilerDriverClassName());
     }
     return cmd;
   }

--- a/src/main/java/scala_maven/ScalaMojoSupport.java
+++ b/src/main/java/scala_maven/ScalaMojoSupport.java
@@ -35,6 +35,7 @@ import scala_maven_dependency.*;
 import scala_maven_executions.JavaMainCaller;
 import scala_maven_executions.JavaMainCallerByFork;
 import scala_maven_executions.JavaMainCallerInProcess;
+import scala_maven_executions.JavaMainCallerInProcess.EntryPoint;
 import util.FileUtils;
 import util.JavaLocator;
 
@@ -507,6 +508,14 @@ public abstract class ScalaMojoSupport extends AbstractMojo {
   }
 
   /**
+   * The {@link EntryPoint} this goal invokes for in-process execution. Defaults to {@link
+   * EntryPoint#MAIN}; subclasses may override to select a different entry point.
+   */
+  protected EntryPoint inProcessEntryPoint() {
+    return EntryPoint.MAIN;
+  }
+
+  /**
    * Get a {@link JavaMainCaller} used invoke a Java process. Typically this will be one of the
    * Scala utilities (Compiler, ScalaDoc, REPL, etc.).
    *
@@ -568,7 +577,9 @@ public abstract class ScalaMojoSupport extends AbstractMojo {
         cmd.addJvmArgs("-Xbootclasspath/a:" + toolcp);
       }
     } else {
-      cmd = new JavaMainCallerInProcess(getLog(), mainClass, toolcp, null, null);
+      cmd =
+          new JavaMainCallerInProcess(
+              getLog(), mainClass, toolcp, null, null, inProcessEntryPoint());
     }
     return cmd;
   }

--- a/src/main/java/scala_maven_dependency/ArtifactIds.java
+++ b/src/main/java/scala_maven_dependency/ArtifactIds.java
@@ -18,6 +18,9 @@ public interface ArtifactIds {
 
   String compilerMainClassName(boolean useFsc) throws Exception;
 
+  /** The concrete compiler driver class exposing an instance {@code process(String[])}. */
+  String compilerDriverClassName() throws Exception;
+
   String consoleMainClassName() throws Exception;
 
   String apidocMainClassName() throws Exception;

--- a/src/main/java/scala_maven_dependency/ArtifactIds4Scala2.java
+++ b/src/main/java/scala_maven_dependency/ArtifactIds4Scala2.java
@@ -38,6 +38,10 @@ public class ArtifactIds4Scala2 implements ArtifactIds {
     return useFsc ? "scala.tools.nsc.CompileClient" : "scala.tools.nsc.Main";
   }
 
+  public String compilerDriverClassName() throws Exception {
+    return "scala.tools.nsc.MainClass";
+  }
+
   public String consoleMainClassName() throws Exception {
     return "scala.tools.nsc.MainGenericRunner";
   }

--- a/src/main/java/scala_maven_dependency/ArtifactIds4Scala3.java
+++ b/src/main/java/scala_maven_dependency/ArtifactIds4Scala3.java
@@ -53,6 +53,10 @@ public class ArtifactIds4Scala3 implements ArtifactIds {
     return "dotty.tools.dotc.Main";
   }
 
+  public String compilerDriverClassName() throws Exception {
+    return "dotty.tools.dotc.Driver";
+  }
+
   public String consoleMainClassName() throws Exception {
     // return "dotty.tools.dotc.Run";
     return "dotty.tools.repl.Main";

--- a/src/main/java/scala_maven_dependency/Context.java
+++ b/src/main/java/scala_maven_dependency/Context.java
@@ -21,6 +21,8 @@ public interface Context {
 
   String compilerMainClassName(String override, boolean useFsc) throws Exception;
 
+  String compilerDriverClassName() throws Exception;
+
   String consoleMainClassName(String override) throws Exception;
 
   String apidocMainClassName(String override) throws Exception;

--- a/src/main/java/scala_maven_dependency/ContextBase.java
+++ b/src/main/java/scala_maven_dependency/ContextBase.java
@@ -39,6 +39,11 @@ abstract class ContextBase implements Context {
   }
 
   @Override
+  public String compilerDriverClassName() throws Exception {
+    return this.aids.compilerDriverClassName();
+  }
+
+  @Override
   public String consoleMainClassName(String override) throws Exception {
     if (StringUtils.isEmpty(override)) {
       return this.aids.consoleMainClassName();

--- a/src/main/java/scala_maven_executions/JavaMainCaller.java
+++ b/src/main/java/scala_maven_executions/JavaMainCaller.java
@@ -7,9 +7,11 @@ package scala_maven_executions;
 import java.io.File;
 
 /**
- * This interface is used to create a call on a main method of a java class.
+ * Invokes a Scala tool's entry point.
  *
- * <p>The important implementations are JavaCommand and ReflectionJavaCaller
+ * <p>{@link JavaMainCallerByFork} runs it as {@code main} in a forked JVM; {@link
+ * JavaMainCallerInProcess} runs it in the current JVM, calling either {@code main} or the
+ * non-exiting {@code process} entry point per its {@link JavaMainCallerInProcess.EntryPoint}.
  *
  * @author J. Suereth
  */

--- a/src/main/java/scala_maven_executions/JavaMainCallerInProcess.java
+++ b/src/main/java/scala_maven_executions/JavaMainCallerInProcess.java
@@ -13,19 +13,28 @@ import org.apache.maven.plugin.logging.Log;
 import org.codehaus.plexus.util.StringUtils;
 
 /**
- * This class will call a java main method via reflection.
+ * Runs a Scala tool in the current JVM via reflection, invoking either its {@code main} or its
+ * non-exiting {@code process} entry point (see {@link EntryPoint}). {@code PROCESS} is used for the
+ * compiler so that an in-process build survives its would-be {@code System.exit}.
  *
  * @author J. Suereth
  *     <p>Note: a -classpath argument *must* be passed into the jvmargs.
  */
 public class JavaMainCallerInProcess extends JavaMainCallerSupport {
 
+  private final EntryPoint entryPoint;
   private ClassLoader _cl;
 
   public JavaMainCallerInProcess(
-      Log mavenLogger, String mainClassName, String classpath, String[] jvmArgs, String[] args)
+      Log mavenLogger,
+      String mainClassName,
+      String classpath,
+      String[] jvmArgs,
+      String[] args,
+      EntryPoint entryPoint)
       throws Exception {
     super(mavenLogger, mainClassName, "", jvmArgs, args);
+    this.entryPoint = entryPoint;
 
     // Pull out classpath and create class loader
     ArrayList<URL> urls = new ArrayList<>();
@@ -53,8 +62,7 @@ public class JavaMainCallerInProcess extends JavaMainCallerSupport {
   @Override
   public boolean run(boolean displayCmd, boolean throwFailure) throws Exception {
     try {
-      runInternal(displayCmd);
-      return true;
+      return runInternal(displayCmd);
     } catch (Exception e) {
       if (throwFailure) {
         throw e;
@@ -79,17 +87,35 @@ public class JavaMainCallerInProcess extends JavaMainCallerSupport {
     return t::isAlive;
   }
 
-  /** Runs the main method of a java class */
-  private void runInternal(boolean displayCmd) throws Exception {
-    String[] argArray = args.toArray(new String[] {});
+  /** Invokes the selected entry point in-process; returns true on success. */
+  private boolean runInternal(boolean displayCmd) throws Exception {
     if (displayCmd) {
+      String[] argArray = args.toArray(new String[] {});
       mavenLogger.info("cmd : " + mainClassName + "(" + StringUtils.join(argArray, ",") + ")");
     }
-    MainHelper.runMain(mainClassName, args, _cl);
+    switch (entryPoint) {
+      case PROCESS:
+        return ProcessHelper.runProcess(mainClassName, args, _cl);
+      case MAIN:
+      default:
+        MainHelper.runMain(mainClassName, args, _cl);
+        return true;
+    }
   }
 
   @Override
   public void redirectToLog() {
     mavenLogger.warn("redirection to log is not supported for 'inProcess' mode");
+  }
+
+  /** Which entry point {@link JavaMainCallerInProcess} invokes on the target class. */
+  public enum EntryPoint {
+    /** The standard {@code static void main(String[])}. */
+    MAIN,
+    /**
+     * The compiler's non-exiting {@code static process(String[])} — the counterpart of {@code main}
+     * that returns instead of calling {@code System.exit}, so an in-process build survives it.
+     */
+    PROCESS
   }
 }

--- a/src/main/java/scala_maven_executions/JavaMainCallerInProcess.java
+++ b/src/main/java/scala_maven_executions/JavaMainCallerInProcess.java
@@ -124,7 +124,8 @@ public class JavaMainCallerInProcess extends JavaMainCallerSupport {
 
   @Override
   public void redirectToLog() {
-    mavenLogger.warn("redirection to log is not supported for 'inProcess' mode");
+    // No-op: in-process the compiler runs in the Maven JVM, so its output already reaches the
+    // same console/log — there is no separate child-process stream to redirect.
   }
 
   /** Which entry point {@link JavaMainCallerInProcess} invokes on the target class. */

--- a/src/main/java/scala_maven_executions/JavaMainCallerInProcess.java
+++ b/src/main/java/scala_maven_executions/JavaMainCallerInProcess.java
@@ -9,6 +9,8 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.maven.plugin.logging.Log;
 import org.codehaus.plexus.util.StringUtils;
 
@@ -22,7 +24,12 @@ import org.codehaus.plexus.util.StringUtils;
  */
 public class JavaMainCallerInProcess extends JavaMainCallerSupport {
 
+  // Cache compiler classloaders by classpath so the compiler loads once and stays JIT-warm across
+  // modules. Safe to share across concurrent compiles because each uses a fresh driver instance.
+  private static final Map<String, ClassLoader> COMPILER_CLASSLOADERS = new ConcurrentHashMap<>();
+
   private final EntryPoint entryPoint;
+  private final String driverClassName;
   private ClassLoader _cl;
 
   public JavaMainCallerInProcess(
@@ -31,12 +38,24 @@ public class JavaMainCallerInProcess extends JavaMainCallerSupport {
       String classpath,
       String[] jvmArgs,
       String[] args,
-      EntryPoint entryPoint)
+      EntryPoint entryPoint,
+      boolean reuseInProcessCompiler,
+      String driverClassName)
       throws Exception {
     super(mavenLogger, mainClassName, "", jvmArgs, args);
     this.entryPoint = entryPoint;
+    this.driverClassName = driverClassName;
+    // Reuse a shared warm classloader only for the compiler (PROCESS); the MAIN path invokes a
+    // singleton main and so gets a fresh classloader.
+    boolean reuse = reuseInProcessCompiler && entryPoint == EntryPoint.PROCESS;
+    _cl =
+        reuse
+            ? COMPILER_CLASSLOADERS.computeIfAbsent(
+                classpath, cp -> buildClassLoader(cp, mavenLogger))
+            : buildClassLoader(classpath, mavenLogger);
+  }
 
-    // Pull out classpath and create class loader
+  private static ClassLoader buildClassLoader(String classpath, Log mavenLogger) {
     ArrayList<URL> urls = new ArrayList<>();
     for (String path : classpath.split(File.pathSeparator)) {
       try {
@@ -46,7 +65,7 @@ public class JavaMainCallerInProcess extends JavaMainCallerSupport {
         mavenLogger.error(e);
       }
     }
-    _cl = new URLClassLoader(urls.toArray(new URL[] {}), null);
+    return new URLClassLoader(urls.toArray(new URL[] {}), null);
   }
 
   @Override
@@ -95,7 +114,7 @@ public class JavaMainCallerInProcess extends JavaMainCallerSupport {
     }
     switch (entryPoint) {
       case PROCESS:
-        return ProcessHelper.runProcess(mainClassName, args, _cl);
+        return ProcessHelper.runProcess(driverClassName, args, _cl);
       case MAIN:
       default:
         MainHelper.runMain(mainClassName, args, _cl);
@@ -113,8 +132,8 @@ public class JavaMainCallerInProcess extends JavaMainCallerSupport {
     /** The standard {@code static void main(String[])}. */
     MAIN,
     /**
-     * The compiler's non-exiting {@code static process(String[])} — the counterpart of {@code main}
-     * that returns instead of calling {@code System.exit}, so an in-process build survives it.
+     * The compiler's non-exiting {@code process(String[])} — the counterpart of {@code main} that
+     * returns instead of calling {@code System.exit}, so an in-process build survives it.
      */
     PROCESS
   }

--- a/src/main/java/scala_maven_executions/ProcessHelper.java
+++ b/src/main/java/scala_maven_executions/ProcessHelper.java
@@ -14,15 +14,18 @@ import java.util.List;
  */
 public class ProcessHelper {
 
-  /** Runs {@code mainClassName}'s {@code process(String[])} in-process; {@code true} on success. */
-  static boolean runProcess(String mainClassName, List<String> args, ClassLoader cl)
+  /** Runs {@code driverClassName}'s instance {@code process(String[])}; {@code true} on success. */
+  static boolean runProcess(String driverClassName, List<String> args, ClassLoader cl)
       throws Exception {
     if (cl == null) {
       cl = Thread.currentThread().getContextClassLoader();
     }
-    // The compiler objects (nsc Main, dotty Main) expose process as a static forwarder.
-    Method process = cl.loadClass(mainClassName).getMethod("process", String[].class);
-    Object result = process.invoke(null, new Object[] {args.toArray(new String[] {})});
+    // A fresh driver instance per compile: the driver holds per-run state in instance fields, so
+    // sharing one across concurrent compiles is unsafe.
+    Class<?> driverClass = cl.loadClass(driverClassName);
+    Object driver = driverClass.getDeclaredConstructor().newInstance();
+    Method process = driverClass.getMethod("process", String[].class);
+    Object result = process.invoke(driver, new Object[] {args.toArray(new String[] {})});
     // nsc's process returns a Boolean success flag; dotty's returns a Reporter.
     if (result instanceof Boolean) {
       return (Boolean) result;

--- a/src/main/java/scala_maven_executions/ProcessHelper.java
+++ b/src/main/java/scala_maven_executions/ProcessHelper.java
@@ -1,0 +1,37 @@
+/*
+ * This is free and unencumbered software released into the public domain.
+ * See UNLICENSE.
+ */
+package scala_maven_executions;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+/**
+ * Helpers for running a Scala compiler's non-exiting {@code process(String[])} entry point
+ * in-process. Unlike {@code main} (which ends in {@code System.exit}), {@code process} returns, so
+ * an in-process build survives it.
+ */
+public class ProcessHelper {
+
+  /** Runs {@code mainClassName}'s {@code process(String[])} in-process; {@code true} on success. */
+  static boolean runProcess(String mainClassName, List<String> args, ClassLoader cl)
+      throws Exception {
+    if (cl == null) {
+      cl = Thread.currentThread().getContextClassLoader();
+    }
+    // The compiler objects (nsc Main, dotty Main) expose process as a static forwarder.
+    Method process = cl.loadClass(mainClassName).getMethod("process", String[].class);
+    Object result = process.invoke(null, new Object[] {args.toArray(new String[] {})});
+    // nsc's process returns a Boolean success flag; dotty's returns a Reporter.
+    if (result instanceof Boolean) {
+      return (Boolean) result;
+    }
+    return !reporterHasErrors(result);
+  }
+
+  /** Whether the {@code Reporter} returned by Scala 3's {@code process} recorded errors. */
+  private static boolean reporterHasErrors(Object reporter) throws ReflectiveOperationException {
+    return (Boolean) reporter.getClass().getMethod("hasErrors").invoke(reporter);
+  }
+}


### PR DESCRIPTION
This PR addresses multi-module in-process builds with `recompileMode=all` specifically:

```xml
<configuration>
  <fork>false</fork>
  <recompileMode>all</recompileMode>
</configuration>
```

Two main changes:

- **feat**: call the compiler's non-exiting `process(String[])` entry point instead of `main`. `main` calls `System.exit`, which kills the Maven JVM after the first module. Added an integration test to verify this works.
- **perf**: reuse the compiler classloader (cached by classpath), but create a new compiler-driver instance per module (each with its own state) to make it work in parallel builds. Added a `reuseInProcessCompiler` flag to disable this reuse (default on). Creating a fresh classloader for every module brings performance down to the `fork=true` level.

Some numbers from building https://github.com/neo4j/neo4j/ on my laptop (`mvn clean install -DskipTests`):

| version              | build  | forked | in-process | speedup |
| -------------------- | ------ | ------ | ---------- | ------- |
| 5.26.29 (Scala 2.13) | serial | 9m03s  | 3m27s      | 2.6×    |
| 5.26.29 (Scala 2.13) | `-T1C` | 6m54s  | 2m09s      | 3.2×    |
| 2026.07 (Scala 3)    | serial | 13m02s | 5m06s      | 2.6×    |
| 2026.07 (Scala 3)    | `-T1C` | 9m41s  | 3m31s      | 2.8×    |

## Note

This PR was generated with help from Claude Code.